### PR TITLE
New ius release available - 1.0-13 gives 404

### DIFF
--- a/playbook/roles/common/tasks/main.yml
+++ b/playbook/roles/common/tasks/main.yml
@@ -24,7 +24,7 @@
     creates=/etc/yum.repos.d/remi.repo
 
 - name: Enable ius repository
-  shell: rpm -Uhv http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-13.ius.centos6.noarch.rpm
+  shell: rpm -Uhv http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-14.ius.centos6.noarch.rpm
     creates=/etc/yum.repos.d/ius.repo
 
 - name: Enable WK repository


### PR DESCRIPTION
When doing vagrant up on a machine, I got this: 

TASK: [common | Enable ius repository] ****************************************
failed: [33.33.33.150] => {"changed": true, "cmd": "rpm -Uhv http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-13.ius.centos6.noarch.rpm", "delta": "0:00:00.503190", "end": "2015-06-08 13:12:16.324169", "rc": 1, "start": "2015-06-08 13:12:15.820979", "warnings": ["Consider using yum module rather than running rpm"]}
stderr: curl: (22) The requested URL returned error: 404 Not Found
error: skipping http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-13.ius.centos6.noarch.rpm - transfer failed
stdout: Retrieving http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-13.ius.centos6.noarch.rpm

FATAL: all hosts have already failed -- aborting
