### PR TITLE
Removed configuration related to Mailcatcher, added instead Mailhog c…

### DIFF
--- a/playbook/roles/devtools/defaults/main.yml
+++ b/playbook/roles/devtools/defaults/main.yml
@@ -1,16 +1,9 @@
 
-
-# the following is also set in web-front - required here for xdebug
-php_package: php53u
-
-# the following is also set in web-front - required here for mailcatcher
-php_ini_file: /etc/php.d/zz_wunderkraut.ini
-
 development_packages:
  - nano
  - ruby-devel
  - sqlite-devel
- - gcc-c++ 
+ - gcc-c++
 
 xdebug:
  - section: XDebug
@@ -18,7 +11,7 @@ xdebug:
     - key: xdebug.remote_enable
       val: 1
     - key: xdebug.remote_handler
-      val: dbgp 
+      val: dbgp
     - key: xdebug.remote_connect_back
       val: 1
     - key: xdebug.remote_port
@@ -28,11 +21,13 @@ xdebug:
     - key: xdebug.remote_log
       val: /var/log/xdebug.log
 
+# mailhog configuration.
+mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.1.7/MailHog_linux_amd64
+mailhog_install_dir: /opt/mailhog
 
-# PHP ini
-php:
- - section: PHP
-   options:
-    - key: sendmail_path
-      val: /usr/bin/catchmail
-      
+# ssmtp configuration.
+ssmtp_mailhub: localhost:1025
+ssmtp_root: postmaster
+ssmtp_authuser: ""
+ssmtp_authpass: ""
+ssmtp_from_line_override: "YES"

--- a/playbook/roles/devtools/files/mailhog
+++ b/playbook/roles/devtools/files/mailhog
@@ -1,0 +1,60 @@
+#! /bin/sh
+# /etc/init.d/mailhog
+#
+# MailHog init script.
+#
+# @author Jeff Geerling
+
+### BEGIN INIT INFO
+# Provides:          mailhog
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start MailHog at boot time.
+# Description:       Enable MailHog.
+### END INIT INFO
+
+PID=/var/run/mailhog.pid
+LOCK=/var/lock/mailhog.lock
+USER=nobody
+BIN=/opt/mailhog/mailhog
+
+# Carry out specific functions when asked to by the system
+case "$1" in
+  start)
+    echo "Starting mailhog."
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  stop)
+    if [ -f $PID ]; then
+      echo "Stopping mailhog.";
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    else
+      echo "MailHog is not running.";
+    fi
+    ;;
+  restart)
+    echo "Restarting mailhog."
+    if [ -f $PID ]; then
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    fi
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  status)
+    if [ -f $PID ]; then
+      echo "MailHog is running.";
+    else
+      echo "MailHog is not running.";
+      exit 3
+    fi
+    ;;
+  *)
+    echo "Usage: /etc/init.d/mailhog {start|stop|status|restart}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/playbook/roles/devtools/tasks/main.yml
+++ b/playbook/roles/devtools/tasks/main.yml
@@ -35,47 +35,45 @@
   notify:
     - restart php-fpm
 
-- name: MAILCATCHER | Install specific version of "i18n" because 0.7.0 has a dependency on Ruby 1.9.3
-  gem: name="i18n" state=present user_install=no version=0.6.11
+# Install and configure MailHog.
+- name: MAILHOG | Ensure mailhog install directory exists.
+  file:
+    path: "{{ mailhog_install_dir }}"
+    owner: root
+    group: root
+    state: directory
+    mode: 0755
 
-- name: MAILCATCHER | Install specific version of "tilt" gem because mailcatcher is picky
-  gem: name="tilt" state=present user_install=no version=1.3.4
+- name: MAILHOG | Download MailHog binary.
+  get_url:
+    url: "{{ mailhog_binary_url }}"
+    dest: "{{ mailhog_install_dir }}/mailhog"
+    owner: root
+    group: root
+    mode: 0755
 
-- name: MAILCATCHER | Install specific version of "mime-types" gem because mailcatcher is really picky
-  gem: name="mime-types" state=present user_install=no version=1.25.1
+- name: MAILHOG | Install the daemonize package.
+  yum: pkg=daemonize state=installed
 
-- name: MAILCATCHER | Install specific version of "i18n" gem because mailcatcher is really really picky
-  gem: name="i18n" state=present user_install=no version=0.6.9
+- name: MAILHOG | Copy mailhog init script into place.
+  copy:
+    src: mailhog
+    dest: /etc/init.d/mailhog
+    owner: root
+    group: root
+    mode: 0755
 
-- name: MAILCATCHER | Install mailcatcher gem
-  gem: name="mailcatcher" state=present user_install=no version=0.5.12
+- name: MAILHOG | Ensure mailhog is enabled and will start on boot.
+  service: name=mailhog state=started enabled=yes
 
-- name: MAILCATCHER | Kill mailcatcher if it's running
-  command: pkill mailcatcher
-  ignore_errors: yes
+- name: MAILHOG | Install sSMTP.
+  yum: pkg=ssmtp state=installed
 
-- name: MAILCATCHER | Launch mailcatcher
-  command: mailcatcher --ip=0.0.0.0
-
-- name: MAILCATCHER | Add sendmail_path setting to {{ php_ini_file }}
-  ini_file: dest={{ php_ini_file }}
-    section="{{ item.0.section }}"
-    option="{{ item.1.key }}"
-    value="{{ item.1.val }}"
-    backup=yes
-  with_subelements:
-    - "{{ php }}"
-    - options
-  notify:
-    - restart php-fpm
-
-- name: MAILCATCHER | Add mailcatcher command to rc.local to have it executed at startup
-  lineinfile: dest=/etc/rc.d/rc.local
-    regexp='^mailcatcher --http-ip=0\.0\.0\.0'
-    insertbefore=BOF
-    line='mailcatcher --http-ip=0.0.0.0'
-
-
-
-
+- name: MAILHOG | Copy sSMTP configuration.
+  template:
+    src: ssmtp.conf.j2
+    dest: /etc/ssmtp/ssmtp.conf
+    owner: root
+    group: root
+    mode: 0644
 

--- a/playbook/roles/devtools/templates/ssmtp.conf.j2
+++ b/playbook/roles/devtools/templates/ssmtp.conf.j2
@@ -1,0 +1,24 @@
+#
+# Config file for sSMTP sendmail
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+root={{ ssmtp_root }}
+
+# The place where the mail goes. The actual machine name is required no
+# MX records are consulted. Commonly mailhosts are named mail.domain.com
+mailhub={{ ssmtp_mailhub }}
+AuthUser={{ ssmtp_authuser }}
+AuthPass={{ ssmtp_authpass }}
+# TODO: Add UseTLS, UseSTARTTLS?
+
+# Where will the mail seem to come from?
+#rewriteDomain=
+
+# The full hostname
+hostname={{ inventory_hostname }}
+
+# Are users allowed to set their own From: address?
+# YES - Allow the user to specify their own From: address
+# NO - Use the system generated From: address
+FromLineOverride={{ ssmtp_from_line_override }}


### PR DESCRIPTION
…onfiguration
- Configuration adapted from https://github.com/geerlingguy/ansible-role-mailhog
- Added daemonize package
- Added sSMTP package
- The web interface for mailhog will be at port 8025.

The sendmail_path variable needs to be added to ansibleref's conf/variables.yml file for this to work.
