### PR TITLE
Remove the xdebug remote log, because it's not needed if not in rare …

### DIFF
--- a/playbook/roles/devtools/defaults/main.yml
+++ b/playbook/roles/devtools/defaults/main.yml
@@ -19,6 +19,9 @@ xdebug:
     - key: xdebug.remote_autostart
       val: 0
 
+# this can be set to true to add the remote log file.
+xdebug_remote_debug_log: false
+
 # mailhog configuration.
 mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.1.7/MailHog_linux_amd64
 mailhog_install_dir: /opt/mailhog

--- a/playbook/roles/devtools/defaults/main.yml
+++ b/playbook/roles/devtools/defaults/main.yml
@@ -18,8 +18,6 @@ xdebug:
       val: 9000
     - key: xdebug.remote_autostart
       val: 0
-    - key: xdebug.remote_log
-      val: /var/log/xdebug.log
 
 # mailhog configuration.
 mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.1.7/MailHog_linux_amd64

--- a/playbook/roles/devtools/tasks/main.yml
+++ b/playbook/roles/devtools/tasks/main.yml
@@ -13,27 +13,42 @@
   with_items:
     - "{{ development_packages }}"
 
+
+##
+# Php XDebug.
+#
+
 - name: PHP | XDebug
   yum: pkg={{ php_package }}-pecl-xdebug state=installed
   tags: ntp
 
-- name: PHP | Add section to the xdebug.ini file if it is missing
-  lineinfile: dest=/etc/php.d/15-xdebug.ini
-    regexp='^[XDebug]'
-    insertbefore=BOF
-    line='[XDebug]'
-
 - name: PHP | Set up xdebug.ini
-  ini_file: dest=/etc/php.d/15-xdebug.ini
+  ini_file: dest=/etc/php.d/zzz-xdebug.ini
     section={{ item.0.section }}
     option={{ item.1.key }}
     value={{ item.1.val }}
-    backup=yes
+    state=present
   with_subelements:
     - "{{ xdebug }}"
     - options
   notify:
     - restart php-fpm
+
+- name: PHP | Set the remote log option in the xdebug ini file.
+  ini_file: dest=/etc/php.d/zzz-xdebug.ini
+    section={{ item.0.section }}
+    option=xdebug.remote_log
+    value=/var/log/xdebug.log
+  with_subelements:
+    - "{{ xdebug }}"
+    - options
+  notify:
+    - restart php-fpm
+  when: xdebug_remote_debug_log == true
+
+- name: PHP | Make sure the xdebug remote log file exists and it writeable
+  file: path=/var/log/xdebug.log state=touch mode="660"
+  when: xdebug_remote_debug_log == true
 
 # Install and configure MailHog.
 - name: MAILHOG | Ensure mailhog install directory exists.


### PR DESCRIPTION
…cases and it produces a lot of annoying warnings.

:)
