### PR TITLE
Adds support for project-specific roles

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -20,6 +20,17 @@ unless File.exist?(dir + "ansible/playbook/vagrant.yml")
 	FileUtils.ln_s "../../conf/vagrant.yml", dir + "ansible/playbook/vagrant.yml"
 end
 
+# Support project-specific ansible roles
+# Loops through local_ansible_roles if it exists and symlinks from ansible/playbook to all folders there.
+if File.exist?(dir + "local_ansible_roles")
+	Dir.foreach('local_ansible_roles') do |item|
+		next if item == '.' or item == '..'
+		unless File.exist?(dir + "ansible/playbook/roles/" + item)
+			FileUtils.ln_s "../../../local_ansible_roles/" + item, dir + "ansible/playbook/roles"
+		end
+	end
+end
+
 # And never anything below this line
 VAGRANTFILE_API_VERSION = "2"
 


### PR DESCRIPTION
This is one simple way we can support project specific role. If you need your own role you can create it as a subfolder in local_ansible_roles, and add it to your vagrant.yml file. 

Vagrant will loop through local_ansible_roles and symlink it into ansible/roles as needed.
