### PR TITLE
Feature/elastic search role

### DIFF
--- a/playbook/roles/elasticsearch/README.md
+++ b/playbook/roles/elasticsearch/README.md
@@ -1,0 +1,1 @@
+# Ansible Role: Elasticsearch

--- a/playbook/roles/elasticsearch/defaults/main.yml
+++ b/playbook/roles/elasticsearch/defaults/main.yml
@@ -1,0 +1,11 @@
+elasticsearch_plugin_dir: /usr/share/elasticsearch/plugins
+elasticsearch_home_dir: /usr/share/elasticsearch
+
+# Define one or more plugins to install with Elasticsearch.
+# The "name" variable is used when installing a plugin, and the
+# "shortname" variable is used when removing it.
+# (due to how the plugin binary works in elasticsearch2.0).
+
+# by default the kopf ui plugin is installed.
+elasticsearch_plugins:
+  - { name: 'lmenezes/elasticsearch-kopf/2.0', shortname: 'kopf'}

--- a/playbook/roles/elasticsearch/files/elasticsearch.repo
+++ b/playbook/roles/elasticsearch/files/elasticsearch.repo
@@ -1,0 +1,6 @@
+[elasticsearch-2.x]
+name=Elasticsearch repository for 2.x packages
+baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/playbook/roles/elasticsearch/handlers/main.yml
+++ b/playbook/roles/elasticsearch/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart elasticsearch
+  service: name=elasticsearch state=restarted

--- a/playbook/roles/elasticsearch/tasks/main.yml
+++ b/playbook/roles/elasticsearch/tasks/main.yml
@@ -16,6 +16,20 @@
 - name: Install Elasticsearch.
   yum: pkg=elasticsearch state=installed
 
+- name: Removing Plugins if they exist
+  action: >
+    shell bin/plugin remove {{ item.shortname }}
+    chdir={{ elasticsearch_home_dir }}
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+
+- name: Installing Plugins
+  action: >
+    shell bin/plugin install {{ item.name }}
+    chdir={{ elasticsearch_home_dir }}
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+
 - name: Configure Elasticsearch.
   lineinfile: >
     dest=/etc/elasticsearch/elasticsearch.yml

--- a/playbook/roles/elasticsearch/tasks/main.yml
+++ b/playbook/roles/elasticsearch/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Install JRE
+  yum: pkg=jre state=installed
+
+- name: Add Elasticsearch GPG key.
+  rpm_key:
+    key: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    state: present
+
+- name: Add Elasticsearch repository.
+  copy:
+    src: elasticsearch.repo
+    dest: /etc/yum.repos.d/elasticsearch.repo
+    mode: 0644
+
+- name: Install Elasticsearch.
+  yum: pkg=elasticsearch state=installed
+
+- name: Configure Elasticsearch.
+  lineinfile: >
+    dest=/etc/elasticsearch/elasticsearch.yml
+    regexp="{{ item.regexp }}"
+    line="{{ item.line }}"
+    state=present
+  with_items:
+    - { regexp: 'network\.host', line: 'network.host: 0.0.0.0' }
+  notify: restart elasticsearch
+
+- name: Start Elasticsearch.
+  service: name=elasticsearch state=started enabled=yes


### PR DESCRIPTION
This branch adds a role to download and configure elastic search in ansible ref.
- elasticsearch 2.0 installed via yum package
- elasticsearch configured to listen to connections not just on localhost but from anywhere
- support for plugins (see the variable in defaults/main.yml) , by default installs the kopf plugin https://github.com/lmenezes/elasticsearch-kopf
- when up: 
  - elasticsearch responds to port 9200: http://local.ansibleref.com:9200/
  - kopf (the UI) to:  http://local.ansibleref.com:9200/_plugin/kopf
