### PR TITLE
Allow disabling content security policy. Allow additional content security policies.

### DIFF
--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -64,8 +64,10 @@ http {
   # Enable X-Frame-Options
   add_header X-Frame-Options "SAMEORIGIN" always;
 
+  {% if nginx_disable_content_security_policy is not defined %}
   # Enable Content Security Policy
-  add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'" always;
+  add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval' {{ nginx_content_security|default('') }}" always;
+  {% endif %}
 
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just


### PR DESCRIPTION
- This would allow content security policies to be disabled in local/dev environments.
- This would also allow additional content security policies (ie. allowing iframes some other sources).
