### PR TITLE
Added config to set $_SERVER['https'] properly from X-Forwarded-Proto…

### DIFF
--- a/playbook/roles/nginx/files/nginx/conf.d/fastcgi_drupal.conf
+++ b/playbook/roles/nginx/files/nginx/conf.d/fastcgi_drupal.conf
@@ -26,6 +26,8 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 fastcgi_param  REDIRECT_STATUS    200;
 
+fastcgi_param  HTTPS              $fe_https;
+
 ## Nginx FCGI specific directives.
 fastcgi_buffer_size 32k;
 fastcgi_buffers 64 8k;

--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -116,6 +116,12 @@ http {
   ## Hide the Nginx version number.
   server_tokens off;
 
+  # Handle HTTPS server variable setting here and in fastcgi_drupal.conf.
+  map $http_x_forwarded_proto $fe_https {
+    default off;
+    https on;
+  }
+
   ## Include nginx configs.
   include conf.d/nginx_*.conf;
 


### PR DESCRIPTION
This fixes issues for servers where https and load balancers are used.
Some Drupal modules seem to use $_SERVER['https'] to determine whether files should be loaded with https or http, and previously that variable was left out.

An example of those modules would be gmap.

```
$this->basejs[url(gmap_views_protocol() . '://maps.googleapis.com/maps/' . 'api/js', array('query' => $query))] = array(
      'type' => 'external',
      'weight' => 1,
    );

function gmap_views_protocol() {
  return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
}
```

Naturally, something like that would end up getting "http://maps.googleapis.com..." as the URL, which the browser would block as being mixed content.
