### PR TITLE
Use Apache foundation's archive url for solr zip file. Our version is…

### DIFF
--- a/playbook/roles/solr/defaults/main.yml
+++ b/playbook/roles/solr/defaults/main.yml
@@ -9,7 +9,7 @@ cache_path: /tmp/solr-cache
 
 # Container folder for solr downloads
 #solr_url: http://www.nic.funet.fi/pub/mirrors/apache.org/lucene/solr/
-solr_url: ftp://ftp.funet.fi/pub/mirrors/apache.org/lucene/solr/
+solr_url: https://archive.apache.org/dist/lucene/solr/
 
 # Version
 solr_version: 4.10.4


### PR DESCRIPTION
… so old that it has disappeared from mirrors.
