### PR TITLE
Use --keep-until-expiring parameter to keep the current certificate if they are valid.

### DIFF
--- a/playbook/roles/certbot/defaults/main.yml
+++ b/playbook/roles/certbot/defaults/main.yml
@@ -5,4 +5,4 @@ certbot_email: test@example.com
 certbot_domains:
   - "{{ ansible_fqdn }}"
 certbot_renewal_docroot: /var/www/certbot-auto
-certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --standalone --standalone-supported-challenges http-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"
+certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --keep-until-expiring --standalone --standalone-supported-challenges http-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"

--- a/playbook/roles/certbot/defaults/main.yml
+++ b/playbook/roles/certbot/defaults/main.yml
@@ -5,4 +5,4 @@ certbot_email: test@example.com
 certbot_domains:
   - "{{ ansible_fqdn }}"
 certbot_renewal_docroot: /var/www/certbot-auto
-certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --keep-until-expiring --standalone --standalone-supported-challenges http-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"
+certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --renew-by-default --standalone --standalone-supported-challenges http-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"


### PR DESCRIPTION
The certbot task will wait endlessly for a user input if it wants to keep the current or renew/replace when a certificate exists already. The --keep-until-expiring parameter will automatically keep the current certificate if it is still valid.
