### PR TITLE
Monitor selenium only by name

### DIFF
--- a/playbook/roles/monit/templates/monitrc.j2
+++ b/playbook/roles/monit/templates/monitrc.j2
@@ -130,10 +130,9 @@ check process browsermob-proxy MATCHING browsermob-proxy
 {% endif %}
 
 {% if monit_check_selenium is defined %}
-check process selenium MATCHING selenium
+check process selenium with pidfile /var/run/selenium/selenium.pid
    group headless
-   start program = "/usr/bin/systemctl start selenium && sleep 2"
+   start program = "/usr/bin/systemctl start selenium"
    stop program = "/usr/bin/systemctl stop selenium"
-   if failed host 127.0.0.1 port 4444 then restart
    if 5 restarts within 15 cycles then timeout
 {% endif %}

--- a/playbook/roles/monit/templates/monitrc.j2
+++ b/playbook/roles/monit/templates/monitrc.j2
@@ -132,7 +132,7 @@ check process browsermob-proxy MATCHING browsermob-proxy
 {% if monit_check_selenium is defined %}
 check process selenium MATCHING selenium
    group headless
-   start program = "/usr/bin/systemctl start selenium"
+   start program = "/usr/bin/systemctl start selenium && sleep 2"
    stop program = "/usr/bin/systemctl stop selenium"
    if failed host 127.0.0.1 port 4444 then restart
    if 5 restarts within 15 cycles then timeout

--- a/playbook/roles/monit/templates/monitrc.j2
+++ b/playbook/roles/monit/templates/monitrc.j2
@@ -130,7 +130,7 @@ check process browsermob-proxy MATCHING browsermob-proxy
 {% endif %}
 
 {% if monit_check_selenium is defined %}
-check process selenium
+check process selenium MATCHING selenium
    group headless
    start program = "/usr/bin/systemctl start selenium"
    stop program = "/usr/bin/systemctl stop selenium"

--- a/playbook/roles/monit/templates/monitrc.j2
+++ b/playbook/roles/monit/templates/monitrc.j2
@@ -130,7 +130,7 @@ check process browsermob-proxy MATCHING browsermob-proxy
 {% endif %}
 
 {% if monit_check_selenium is defined %}
-check process selenium with pidfile /var/run/selenium/selenium.pid
+check process selenium
    group headless
    start program = "/usr/bin/systemctl start selenium"
    stop program = "/usr/bin/systemctl stop selenium"


### PR DESCRIPTION
Selenium is so slow to start the serving at port 4444 that the check fails, but it seems to work fine by only checking with the service name without the port check.
