### PR TITLE
Add support for authcache.php in nginx configuration.

### DIFF
--- a/playbook/roles/web-front/files/drupal.conf
+++ b/playbook/roles/web-front/files/drupal.conf
@@ -119,6 +119,13 @@ location ~ ^(/.*/radioactivity/emit.php)$ {
   fastcgi_pass phpcgi;
 }
 
+## Allow Authcache's frontcontroller authcache.php
+location = /authcache.php {
+  include conf.d/fastcgi_drupal.conf;
+  fastcgi_param  SCRIPT_FILENAME    $document_root/authcache.php;
+  fastcgi_pass phpcgi;
+}
+
 ## Allow running _ping.php
 location = /_ping.php {
   include conf.d/fastcgi_drupal.conf;


### PR DESCRIPTION
In Tekla Downloads, we use authcache, which depends on having authcache.php in Drupal's root. We can copy it in place with the build script, but we also depend on nginx allowing requests through.
