### PR TITLE
Varnish 4 control key support

### DIFF
--- a/playbook/roles/base/tasks/system.yml
+++ b/playbook/roles/base/tasks/system.yml
@@ -121,6 +121,12 @@
     line="WKV_SITE_ENV={{ wkv_site_env }}"
     backup=yes
 
+- lineinfile:
+    dest=/etc/environment
+    line="VARNISH_CONTROL_KEY={{ varnish.control_key }}"
+    backup=yes
+  when: varnish.control_key is defined
+
 # Disable firewalld and make sure it stays off, we rely on HARDWARE firewalls.
 - service: name=firewalld state=stopped
   when:

--- a/playbook/roles/php-fpm/templates/www.conf.j2
+++ b/playbook/roles/php-fpm/templates/www.conf.j2
@@ -27,4 +27,5 @@ rlimit_core = unlimited
 php_admin_value[error_log] = /var/log/php-fpm/www-error.log
 php_admin_flag[log_errors] = on
 env[WKV_SITE_ENV] = {{ wkv_site_env }}
+env[VARNISH_CONTROL_KEY] = {{ varnish.control_key }}
 

--- a/playbook/roles/php-fpm/templates/www.conf.j2
+++ b/playbook/roles/php-fpm/templates/www.conf.j2
@@ -27,5 +27,5 @@ rlimit_core = unlimited
 php_admin_value[error_log] = /var/log/php-fpm/www-error.log
 php_admin_flag[log_errors] = on
 env[WKV_SITE_ENV] = {{ wkv_site_env }}
-env[VARNISH_CONTROL_KEY] = {{ varnish.control_key }}
+env[VARNISH_CONTROL_KEY] = {% if varnish.control_key is defined %}{{ varnish.control_key }}{% endif %}
 

--- a/playbook/roles/php-fpm/templates/www.conf.j2
+++ b/playbook/roles/php-fpm/templates/www.conf.j2
@@ -27,5 +27,5 @@ rlimit_core = unlimited
 php_admin_value[error_log] = /var/log/php-fpm/www-error.log
 php_admin_flag[log_errors] = on
 env[WKV_SITE_ENV] = {{ wkv_site_env }}
-env[VARNISH_CONTROL_KEY] = {% if varnish.control_key is defined %}{{ varnish.control_key }}{% endif %}
+{% if varnish.control_key is defined %}env[VARNISH_CONTROL_KEY] = {{ varnish.control_key }}{% endif %}
 

--- a/playbook/roles/varnish/tasks/main.yml
+++ b/playbook/roles/varnish/tasks/main.yml
@@ -22,6 +22,14 @@
   notify:
     - restart varnish
 
+- template:
+    src=varnish.secret.j2
+    dest=/etc/varnish/secret
+    backup=yes
+  notify:
+    - restart varnish
+  when: varnish.control_key is defined
+
 - name: Add extra definitions
   blockinfile:
     dest: "{{ item.dest }}"

--- a/playbook/roles/varnish/templates/varnish.secret.j2
+++ b/playbook/roles/varnish/templates/varnish.secret.j2
@@ -1,0 +1,1 @@
+{{ varnish.control_key }}


### PR DESCRIPTION
Added support for a Varnish control key variable (varnish.control_key) which if set will do the following:  
- Adds a line in _/etc/environment_: `VARNISH_CONTROL_KEY=[control_key value]`
- Adds a line in _/etc/php-fpm.d/www.conf_: `env[VARNISH_CONTROL_KEY] = [control_key value]`
- Creates a _/etc/varnish/secret_ file with control_key value

**Benefits**:
Allows for a common control key in Drupal settings between local boxes (/etc/varnish/secret is a randomly generated UUID by default). Can be set in vagrant.settings.php: `$conf['varnish_control_key'] = getenv('VARNISH_CONTROL_KEY');`
