### PR TITLE
Duplicate vcl_synth callbacks causes error template not to work

### DIFF
--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -509,22 +509,7 @@ sub vcl_synth {
     set resp.http.Location = resp.reason;
     set resp.status = 302;
     return (deliver);
-  }
-
-  return (deliver);
-}
-
-
-sub vcl_fini {
-  # Called when VCL is discarded only after all requests have exited the VCL.
-  # Typically used to clean up VMODs.
-
-  return (ok);
-}
-
-sub vcl_synth{
-
-  if(resp.status >= 500){
+  } elseif (resp.status >= 500){
     // Custom error
     set resp.http.Cache-Control = "no-cache, max-age: 0, must-revalidate";
     set resp.http.x-sitename = "insert_sitename";
@@ -564,5 +549,14 @@ sub vcl_synth{
   "} );
     return (deliver);
   }
+
   return (deliver);
+}
+
+
+sub vcl_fini {
+  # Called when VCL is discarded only after all requests have exited the VCL.
+  # Typically used to clean up VMODs.
+
+  return (ok);
 }


### PR DESCRIPTION
While testing error template I encountered an blank page with regular 500 server error.

After finding out that there are two `vcl_synth` callbacks and testing the custom template inside the first `vcl_synth` callback, I found out that it worked out as expected.

Therefore I merged the custom error template inside the first `sub vcl_synth`
