### PR TITLE
Explicitly specify LC_CTYPE to prevent error messages when logging in.

### DIFF
--- a/playbook/roles/base/tasks/system.yml
+++ b/playbook/roles/base/tasks/system.yml
@@ -127,6 +127,16 @@
     backup=yes
   when: varnish.control_key is defined
 
+- lineinfile:
+    dest=/etc/locale.conf
+    line="LC_CTYPE=en_US.utf8"
+    backup=yes
+
+- lineinfile:
+    dest=/etc/locale.conf
+    line="LC_ALL=en_US.utf8"
+    backup=yes
+
 # Disable firewalld and make sure it stays off, we rely on HARDWARE firewalls.
 - service: name=firewalld state=stopped
   when:


### PR DESCRIPTION
For users that haven't configured their terminals properly (like me on a new mac), locale spews
out an error message when logging in to vagrant boxes:

`-bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory`

This error also prevents mongo from starting, printing this message:
`Failed global initialization: BadValue Invalid or no user locale set. Please ensure LANG and/or LC_* environment variables are set correctly.`

A Google search reveals many people having the same issue. Would be nice if WunderTools was
kind enough to fix it on us lazy user's part.

Note: We're using the same locale name as output by CentOS' `locale -a` command.
