### PR TITLE
Set PHP's memory limit to 256M and not 256 bytes.

### DIFF
--- a/playbook/roles/php-fpm/templates/php.ini.j2
+++ b/playbook/roles/php-fpm/templates/php.ini.j2
@@ -1,5 +1,5 @@
 [PHP]
-memory_limit = {{ php_memory_limit }}
+memory_limit = {{ php_memory_limit }}M
 realpath_cache_size = 256K
 realpath_cache_ttl = 7200
 max_execution_time = 60


### PR DESCRIPTION
It may prevent error messages like the following:

`PHP Fatal error:  Allowed memory size of 262144
bytes exhausted (tried to allocate 533 bytes) in Unknown on line 0`
