### PR TITLE
Add support for turning on SSH agent forwarding to the vagrant box.

### DIFF
--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -123,7 +123,7 @@ sub vcl_recv {
 
   # Add a unique header containing the client address
   if (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
-    set req.http.X-Forwarded-For = req.http.X-Forwarded-For;
+    set req.http.X-Forwarded-For = req.http.X-Real-IP;
   } else {
     set req.http.X-Forwarded-For = client.ip;
   }

--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -11,6 +11,7 @@ INSTANCE_CPUS     = settings['cpus']
 INSTANCE_IP       = settings['ip']
 INSTANCE_BOX      = settings['box']
 INSTANCE_ALIASES  = settings['aliases']
+SSH_FORWARD_AGENT  = settings['config.ssh.forward_agent']
 
 # Link the ansible playbook
 unless File.exist?(dir + "ansible/playbook/vagrant.yml")
@@ -53,6 +54,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 			type: :nfs,
 			mount_options: ['rw', 'vers=3', 'tcp', 'nolock', 'actimeo=1']
 		}
+	end
+
+	# SSH configuration - requires config.ssh.forward_agent: true in vagrant_local.yml
+	if SSH_FORWARD_AGENT
+	  config.ssh.forward_agent = true
 	end
 
 	########################################


### PR DESCRIPTION
This allows developers to clone git repositories from inside the
vagrant box which is necessary in some projects.

To use it, simply add "config.ssh.forward_agent: true" to
`conf/vagrant_local.yml`.

PS: It also requires the vagrant box to have `ForwardAgent yes` in `/etc/ssh/ssh_config` - so far we have resolved that with a local ansible role.

For more settings, see
https://www.vagrantup.com/docs/vagrantfile/ssh_settings.html
