### PR TITLE
Add more settings for mariadb, clean up dbserver role's main.yml

### DIFF
--- a/playbook/roles/dbserver/defaults/main.yml
+++ b/playbook/roles/dbserver/defaults/main.yml
@@ -3,16 +3,15 @@ partition_var_lib_mysql: True
 
 mariadb_root_password: root
 
-innodb_buffer_pool_size: 1024
-
 max_connections: 500
-
+connection_timeout: 5
+wait_timeout: 60
 max_allowed_packet: 256M
-
+innodb_buffer_pool_size: 1024
 innodb_buffer_pool_instances: 6
-
+innodb_log_buffer_size: 8M
+innodb_log_file_size: 24M
+innodb_additional_mem_pool_size: 10M
 innodb_concurrency: 16
 
-connection_timeout: 5
-
-wait_timeout: 60
+max_allowed_packet: 128M

--- a/playbook/roles/dbserver/templates/my.cnf.j2
+++ b/playbook/roles/dbserver/templates/my.cnf.j2
@@ -80,12 +80,13 @@ innodb_buffer_pool_size = {{ innodb_buffer_pool_size }}M
 innodb_buffer_pool_instances    = {{ innodb_buffer_pool_instances }}
 
 innodb_data_file_path = ibdata1:200M:autoextend
-innodb_log_buffer_size = 8M
+innodb_log_buffer_size = {{ innodb_log_buffer_size }}
+innodb_log_file_size = {{ innodb_log_file_size }}
 innodb_file_per_table = 1
 innodb_open_files = 32768
 innodb_io_capacity = 400
 innodb_thread_concurrency = {{ innodb_concurrency }}
-innodb_additional_mem_pool_size = 10M
+innodb_additional_mem_pool_size = {{ innodb_additional_mem_pool_size }}
 innodb_read_io_threads = {{ innodb_concurrency }}
 innodb_write_io_threads = {{ innodb_concurrency }}
 innodb_flush_log_at_trx_commit = 0
@@ -109,4 +110,4 @@ slow_query_log = 0
 [mysqldump]
 quick
 quote-names
-max_allowed_packet  = 128M
+max_allowed_packet  = {{ max_allowed_packet }}


### PR DESCRIPTION
I needed a bigger `innodb_log_file_size` to be able to restore a dumpfile. 

While I was at it, I reordered the settings in `ansible/playbook/roles/dbserver/defaults/main.yml` so that they match the order in `ansible/playbook/roles/dbserver/templates/my.cnf.j2`. This makes it easier to navigate the two files.