### PR TITLE
Fixed with_dict syntax for ansible 2.2

### DIFF
--- a/playbook/roles/database/tasks/main.yml
+++ b/playbook/roles/database/tasks/main.yml
@@ -46,11 +46,11 @@
 
   - name: Setup databases
     mysql_db: name={{ item.key }} state=present
-    with_dict: databases
+    with_dict: "{{ databases }}"
 
   - name: Setup database users
     mysql_user: name={{ item.value.user }} password={{ item.value.pass }} priv={{ item.key }}.*:ALL state=present
-    with_dict: databases
+    with_dict: "{{ databases }}"
 
   - name: Install Pipe Viewer for monitoring MySQL imports
     yum: pkg=pv state=latest


### PR DESCRIPTION
This fixes #92 but needs to be tested with ansible 1.x before merging. Tested with 2.2 and works fine.