### PR TITLE
Only virtualbox needs to use older working box version.

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -44,11 +44,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	config.vm.hostname = INSTANCE_HOSTNAME
 	config.vm.box      = INSTANCE_BOX
 
-  # Set default box version
-	if INSTANCE_VERSION.to_s != ''
-		config.vm.box_version = INSTANCE_VERSION
-	else
-		config.vm.box_version = '1.1.2'
+	#Virtualbox has issues with the latest Centos6 box (1.1.3) so we forcing previous version.
+
+	config.vm.provider :virtualbox do |vb|
+	  # Set default box version
+		if INSTANCE_VERSION.to_s != ''
+			config.vm.box_version = INSTANCE_VERSION
+		else
+			config.vm.box_version = '1.1.2'
+		end
 	end
 
 	config.vm.network :private_network, ip: INSTANCE_IP


### PR DESCRIPTION
We tested that VMWare was working on the latest geerlingguy centos box so versioning for it is not needed. Also we noticed that both of the VM's are not always supported. There were versions where wmvare box was missing. That already caused an issue.