### PR TITLE
Use --preferred-challenges flag instead of standalone specific challenge flag which is now deprecated

### DIFF
--- a/playbook/roles/certbot/defaults/main.yml
+++ b/playbook/roles/certbot/defaults/main.yml
@@ -5,4 +5,4 @@ certbot_email: test@example.com
 certbot_domains:
   - "{{ ansible_fqdn }}"
 certbot_renewal_docroot: /var/www/certbot-auto
-certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --renew-by-default --standalone --standalone-supported-challenges http-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"
+certbot_command: "{{ certbot_src }}/certbot/certbot-auto certonly --renew-by-default --standalone --preferred-challenges http-01,tls-sni-01 --agree-tos --text {% for domain in certbot_domains %}-d {{ domain }} {% endfor %}--email {{ certbot_email }}"


### PR DESCRIPTION
Fixes the warning below:
stderr: WARNING: The standalone specific supported challenges flag is deprecated.
Please use the --preferred-challenges flag instead.