### PR TITLE
Specify the “create” attribute for the ini_file zzz-xdebug.ini in the…

### DIFF
--- a/playbook/roles/devtools/tasks/main.yml
+++ b/playbook/roles/devtools/tasks/main.yml
@@ -52,6 +52,7 @@
     option={{ item.1.key }}
     value={{ item.1.val }}
     state=present
+    create=yes
   with_subelements:
     - "{{ xdebug }}"
     - options


### PR DESCRIPTION
… devtools task, because it’s not as optional as the ansible documentation says. 

The documentation here: http://docs.ansible.com/ansible/ini_file_module.html says that this parameter was added to ansible 2.2 (which I am testing), and that it should be optional, but actually the provisioning fails without it so let's add it.