### PR TITLE
Set nginx to support redirection from http to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
+.idea
 .DS_Store

--- a/playbook/roles/nginx/templates/all_apps.conf.j2
+++ b/playbook/roles/nginx/templates/all_apps.conf.j2
@@ -28,6 +28,15 @@ server {
 
 {% endif %}
 
+{% if site.redirect_to_https is defined %}
+# Redirect to https
+server {
+    listen {{ site.http_port }};
+    server_name {{ site.server_name }};
+    return 301 https://$server_name$request_uri;
+}
+{% endif %}
+
 {% if site.docroot is defined %}
 # HTTP Site {{ site.server_name }} => php-fpm
 server {


### PR DESCRIPTION
Example use case:

apps:
  - server_name: www.test.com default_server
    http_port: 443
    docroot: /var/www/test.com/current
  - server_name: www.test.com
    http_port: 80 default_server
    redirect_to_https: true