### PR TITLE
Fix setting of ssh forward agent

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -12,7 +12,7 @@ INSTANCE_IP       = settings['ip']
 INSTANCE_BOX      = settings['box']
 INSTANCE_ALIASES  = settings['aliases']
 INSTANCE_VERSION  = settings['box_version']
-SSH_FORWARD_AGENT  = settings['config.ssh.forward_agent']
+SSH_FORWARD_AGENT  = settings['ssh_forward_agent']
 
 # And never anything below this line
 VAGRANTFILE_API_VERSION = "2"


### PR DESCRIPTION
Simplify setting of ssh forward agent in vagrantfile.rb
From:
SSH_FORWARD_AGENT  = settings['config.ssh.forward_agent']
To:
SSH_FORWARD_AGENT  = settings['ssh_forward_agent']