### PR TITLE
Allow extra headers to be set for each site with optional location block

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -12,6 +12,9 @@ apps:
     server_forwards: test.com
     http_port: 8080
     docroot: /var/www/test.com/current
+#    extra_headers:
+#      - { name: "Access-Control-Allow-Origin", value: "https://www.somesite1.com", location: "/some/location" }
+#      - { name: "Access-Control-Allow-Origin", value: "https://www.somesite2.com" }
   - server_name: test2.com
     server_aliases: www.example35.com www.example53.com
     http_port: 8080

--- a/playbook/roles/nginx/templates/all_apps.conf.j2
+++ b/playbook/roles/nginx/templates/all_apps.conf.j2
@@ -68,6 +68,19 @@ server {
 
   include conf.d/drupal.conf;
   include conf.d/php_fpm_status.conf;
+
+  {% if site.extra_headers is defined %}
+  # Extra headers.
+  {% for header in site.extra_headers %}
+  {% if header.location is defined %}
+  location {{ header.location }} {
+    add_header {{ header.name }} {{header.value}};
+  }
+  {% else %}
+  add_header {{ header.name }} {{header.value}};
+  {% endif %}
+  {% endfor %}
+  {% endif %}
 }
 
 {% endif %}


### PR DESCRIPTION
Use case example: Access-Control-Allow-Origin header for a specific site (CORS)

Usage example in wundertools:

```
apps:
  - server_name: local.site.com
    http_port: 8080
    docroot: /var/www/local
    extra_headers:
      - { name: "Access-Control-Allow-Origin", value: "https://www.somesite1.com", location: "/some/location" }
      - { name: "Access-Control-Allow-Origin", value: "https://www.somesite2.com" }
```