### PR TITLE
Fix wrong syntax generated by jinja template. The variable in Jinja is a list which fails the "is mapping" condition

### DIFF
--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -24,12 +24,12 @@ events {
 
 http {
   ## Get correct ip from X-Forwarded-For as we are behind Varnish
-  {% if nginx_real_ip is mapping %}
+  {% if nginx_real_ip is string %}
+  set_real_ip_from   {{ nginx_real_ip }};
+  {% else %}
   {% for real_ip in nginx_real_ip %}
   set_real_ip_from   {{ real_ip }};
   {% endfor %}
-  {% else %}
-  set_real_ip_from   {{ nginx_real_ip }};
   {% endif %}
   real_ip_header     X-Forwarded-For;
 


### PR DESCRIPTION
Background:

Our nginx provisioning failed earlier because ansible generated a string of the list in nginx config.

Our nginx config contains something like:

`    nginx_real_ip:
      - 192.168.1.0/22
      - 192.168.2.0/22`

Which generated:

`set_real_ip_from   [u'192.168.1.0/22',u'192.168.2.0/22'];`

Ansible version is: 2.2

The reason for this is because in Jinja the type of variable "nginx_real_ip" is a list, so it returns false when we check with the condition "is mapping" (which only returns true for dictionaries?).

The change assume that everything is either a dict or list, if it's string then it only generates one line.