### PR TITLE
Fixes the not working certificate renewal for certbot if path is wrong.

### DIFF
--- a/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
+++ b/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
@@ -19,7 +19,11 @@ server {
 
     location ~* /.well-known/acme-challenge {
       default_type "text/plain";
+    {% if certbot_renewal_docroot is defined %}
+      root        {{ certbot_renewal_docroot }};
+    {% else  %}
       root        /var/www/letsencrypt-auto;
+    {% endif %}
     }
 
     {% if site.extra_forwards is defined %}


### PR DESCRIPTION
If certbot_renewal_docroot is defined, use that path for the certificate renewal, otherwise use the original letsencrypt-auto.