### PR TITLE
Allow disabling of x-frame-options default header so applications could control it on its own

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -6,6 +6,10 @@ nginx_papertrail_follow:
   - /var/log/drupal.log
   - /var/log/nginx/http-*error.log
 
+# Add this to ansible configuration to disable the default x-frame-option (SAME ORIGIN)
+# to allow applications to control the header.
+# nginx_disable_default_xframe_options: True
+
 apps:
   - server_name: www.test.com
     server_aliases: bob.com
@@ -39,5 +43,3 @@ nginx_conf:
   client_max_body_size: 100M
   client_body_buffer_size: 128k
   proxy_read_timeout: 60
-
-

--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -67,8 +67,10 @@ http {
   # Enable HSTS;
   add_header Strict-Transport-Security max-age=31536000;
 
+  {% if nginx_disable_default_xframe_options is not defined %}
   # Enable X-Frame-Options
   add_header X-Frame-Options "SAMEORIGIN" always;
+  {% endif %}
 
   {% if nginx_disable_content_security_policy is not defined %}
   # Enable Content Security Policy

--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -61,14 +61,16 @@ http {
   # Enable HSTS;
   add_header Strict-Transport-Security max-age=31536000;
 
+  {% if nginx_disable_default_xframe_options is not defined %}
   # Enable X-Frame-Options
   add_header X-Frame-Options "SAMEORIGIN" always;
+  {% endif %}
 
   {% if nginx_disable_content_security_policy is not defined %}
   # Enable Content Security Policy
   add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'{{ nginx_content_security|default('') }}" always;
   {% endif %}
-  
+
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just
   ## reinstate in case it has been somehow disabled for this


### PR DESCRIPTION
The default x-frame-options is SAMEORIGIN. Setting `nginx_disable_default_xframe_options: True` in ansible would disable it giving the applications the ability to set and control it.
