### PR TITLE
Allow upcloud-firewall to fail in cases where the project uses multiple different credentials

### DIFF
--- a/playbook/roles/upcloud-firewall/tasks/firewalls.yml
+++ b/playbook/roles/upcloud-firewall/tasks/firewalls.yml
@@ -134,6 +134,7 @@
     - "{{ groups['wundertools-dev']|default([]) }}"
     - "{{ groups['wundertools-stage']|default([]) }}"
     - "{{ groups['wundertools-prod-lb']|default([]) }}"
+  ignore_errors: yes
 
 - name: Setup firewalls for the backend groups
   upcloud_firewall:
@@ -143,3 +144,4 @@
   with_flattened:
     - "{{ groups['wundertools-prod-db']|default([]) }}"
     - "{{ groups['wundertools-prod-front']|default([]) }}"
+  ignore_errors: yes


### PR DESCRIPTION
We have few cases where we need to run the `upcloud-firewall` role with multiple different Upcloud credentials.

In this case few machines will fail with `IP_ADDRESS_FORBIDDEN` exception but we want to continue with other machines and then re-run the playbook with other credentials.