### PR TITLE
Upcloud Servers: Allow resizing and setting backups for disks of running servers

### DIFF
--- a/playbook/library/upcloud_server.py
+++ b/playbook/library/upcloud_server.py
@@ -151,7 +151,9 @@ EXAMPLES = '''
 '''
 
 from distutils.version import LooseVersion
+from upcloud_api.errors import UpCloudClientError, UpCloudAPIError
 
+import itertools
 import os
 
 # make sure that upcloud-api is installed
@@ -191,7 +193,6 @@ class ServerManager():
 
         # try with hostname, if given and nothing was found with uuid
         if hostname:
-            # Get all servers with populated data
             servers = self.manager.get_servers(True)
 
             found_servers = []
@@ -232,7 +233,7 @@ class ServerManager():
         server_dict = self.collect_server_params(module)
 
         # These paramaters are not supported when modifying the server
-        for item in ['zone','storage_devices','login_user']:
+        for item in ['zone','storage_devices','login_user','allow_reboot_on_resize']:
             del server_dict[item]
 
         return self.manager.modify_server(uuid, **server_dict)
@@ -267,8 +268,11 @@ class ServerManager():
         # If this request wasn't about the disks just skip this section
         if not 'storage_devices' in server_spec:
             return
-
+            
         server_info = server.to_dict()
+
+        # Disk resize commands can fail if machine is not stopped
+        resize_commands = []
 
         # Loop all created disks from the server
         for disk in server_info['storage_devices']:
@@ -286,12 +290,50 @@ class ServerManager():
                 uuid = disk['storage']
                 size = disk_spec['size']
                 title = disk_spec['title']
-                backup_rule = {}
                 if 'backup_rule' in disk_spec:
                     backup_rule = disk_spec['backup_rule']
+                else:
+                    backup_rule = {}
 
                 # Update the storage settings
-                self.manager.modify_storage(uuid, size, title, backup_rule)
+                try:
+                    self.manager.modify_storage(uuid, size, title, backup_rule)
+                except UpCloudAPIError as e:
+                    if e.error_code == 'SERVER_STATE_ILLEGAL' and server_info['state'] == 'started':
+                        # These commands will only succeed if the machine is turned off
+                        resize_commands.append({
+                            'uuid': uuid,
+                            'size': size,
+                            'storage_title': title,
+                            'backup_rule': backup_rule,
+                            'address': disk['address']
+                        })
+
+        # Reboot is needed for these commands: 
+        if resize_commands and module.params.get('allow_reboot_on_resize'):
+
+            initial_timeout = self.manager.timeout
+
+            # Allow longer timeout for starting/stopped the machine
+            self.manager.timeout=360
+
+            # Stop the machine and wait until it's shutdown
+            server.ensure_stopped()
+
+            # Resize all disks
+            for disk in resize_commands:
+                self.manager.modify_storage(disk['uuid'], disk['size'], disk['storage_title'], disk['backup_rule'])
+
+            # Start the machine and wait until it's back online
+            server.ensure_started()
+
+            self.manager.timeout = initial_timeout
+
+            return resize_commands
+
+        return {}
+
+
 
 
 def run(module, server_manager):
@@ -308,6 +350,8 @@ def run(module, server_manager):
     if state == 'present':
         server = server_manager.find_server(uuid, hostname, ip_address)
 
+        modifications = dict()
+
         if not server:
             # create server, if one was not found
             server = server_manager.create_server(module)
@@ -316,7 +360,6 @@ def run(module, server_manager):
             server_wanted = server_manager.collect_server_params(module)
             changed = False
 
-            modifications = dict()
             for field in server_wanted:
                 if hasattr(server,field):
                     attrs = getattr(server, field)
@@ -332,10 +375,14 @@ def run(module, server_manager):
             if changed:
                 server = server_manager.modify_server(server.uuid, module)
 
-        # Checks the state of disk backups
-        server_manager.ensure_storage_devices(server, module)
-
         server.ensure_started()
+
+        # Checks the state of disk backups
+        modifications['storage_devices'] = server_manager.ensure_storage_devices(server, module)
+
+        if modifications['storage_devices']:
+            # Update the information about new disk sizes
+            server = server_manager.find_server(uuid, hostname, ip_address)
 
         module.exit_json(changed=changed, modifications=modifications, server=server.to_dict(), public_ip=server.get_public_ip())
 
@@ -378,6 +425,7 @@ def main():
             firewall = dict(type='bool'),
             ssh_keys = dict(type='list'),
             user = dict(type='str'),
+            allow_reboot_on_resize = dict(type='bool', default=False),
 
             # optional, nice-to-have
             vnc = dict(type='bool'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-ansible==2.2.1.0
+ansible==2.3.0.0
+pyOpenSSL==16.2.0
+# Required for 'json_query' filter in ansible playbooks
+jmespath==0.9.2
 # Required for 'ipaddr' filter in ansible playbooks
 netaddr==0.7.19
 # Install upcloud-api from Wunder fork github master
-git+git://github.com/UpCloudLtd/upcloud-python-api@577becf292e08484eb5ad54fe2a73651ce41b811#egg=upcloud-api
+git+git://github.com/UpCloudLtd/upcloud-python-api@master#egg=upcloud-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ jmespath==0.9.2
 # Required for 'ipaddr' filter in ansible playbooks
 netaddr==0.7.19
 # Install upcloud-api from Wunder fork github master
-git+git://github.com/UpCloudLtd/upcloud-python-api@master#egg=upcloud-api
+git+git://github.com/wunderkraut/upcloud-python-api@master#egg=upcloud-api


### PR DESCRIPTION
By providing:

```
upcloud_server:
  allow_reboot_on_resize: true
```

You will tell ansible that it's okay to shutdown the machines while growing the disks.