### PR TITLE
Add quotes around any ENV in php-fpm config.

### DIFF
--- a/playbook/roles/php-fpm/templates/www.conf.j2
+++ b/playbook/roles/php-fpm/templates/www.conf.j2
@@ -26,10 +26,10 @@ rlimit_files = 131072
 rlimit_core = unlimited
 php_admin_value[error_log] = /var/log/php-fpm/www-error.log
 php_admin_flag[log_errors] = on
-env[WKV_SITE_ENV] = {{ wkv_site_env }}
+env[WKV_SITE_ENV] = "{{ wkv_site_env }}"
 {% if varnish is defined %}
 {% if varnish.control_key is defined %}
-env[VARNISH_CONTROL_KEY] = {{ varnish.control_key }}
+env[VARNISH_CONTROL_KEY] = "{{ varnish.control_key }}"
 {% endif %}
 {% endif %}
 

--- a/playbook/roles/php-fpm/templates/www.conf.php7.j2
+++ b/playbook/roles/php-fpm/templates/www.conf.php7.j2
@@ -32,7 +32,7 @@ php_value[soap.wsdl_cache_dir]  = /var/lib/php/fpm/wsdlcache
 
 {% if php_env_vars is defined %}
 {% for variable in php_env_vars %}
-env[{{ variable.key }}] = {{ variable.value }}
+env[{{ variable.key }}] = "{{ variable.value }}"
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
 This prevents php-fpm for failing when there's special characters like '~' in the password.