### PR TITLE
Add upgrade-insecure-requests to Content-Security-Policy

### DIFF
--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -74,7 +74,7 @@ http {
 
   {% if nginx_disable_content_security_policy is not defined %}
   # Enable Content Security Policy
-  add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval' {{ nginx_content_security|default('') }}" always;
+  add_header Content-Security-Policy "upgrade-insecure-requests; default-src https: data: 'unsafe-inline' 'unsafe-eval' {{ nginx_content_security|default('') }}" always;
   {% endif %}
 
   ## Enable the builtin cross-site scripting (XSS) filter available


### PR DESCRIPTION
This will help us to migrate old sites to https. All current browsers excluding IE and Edge are supporting this directive.

https://caniuse.com/#search=upgrade-insecure-requests

So this won't fix everything but it will automatically fix many browsers so we can at least avoid the problems of `http://` assets for many end-users.