### PR TITLE
Check if httpsforwards is defined before using it

### DIFF
--- a/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
+++ b/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
@@ -41,9 +41,10 @@ server {
 
 {% endfor %}
 
-{% for site in httpsforwards %}
+{% if httpsforwards is defined %}
+  {% for site in httpsforwards %}
+    {% if site.forwarded_domains is defined %}
 
-{% if site.forwarded_domains is defined %}
 # HTTPS Forwarder
 server {
     listen 443 http2 ssl;
@@ -66,9 +67,9 @@ server {
     }
 }
 
+    {% endif %}
+  {% endfor %}
 {% endif %}
-
-{% endfor %}
 
 {% if httpextraforwards is defined %}
 {% for site in httpextraforwards %}


### PR DESCRIPTION
This fixes problems with `httpsforwards`:
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "AnsibleUndefinedVariable: 'httpsforwards' is undefined"
}
```

Which was found in:
https://github.com/wunderkraut/WunderMachina/pull/198#pullrequestreview-48276701