### PR TITLE
Reset chrome driver version to last supported.

### DIFF
--- a/playbook/roles/selenium/defaults/main.yml
+++ b/playbook/roles/selenium/defaults/main.yml
@@ -4,6 +4,7 @@ selenium_install_dir: /opt
 selenium_version: "3.4.0"
 selenium_install_firefox: yes
 selenium_install_chrome: yes
+selenium_chromedriver: "2.30"
 selenium_display_id: "1"
 selenium_port: 4444
 selenium_xvfb_args: "--server-args='-screen 0, 1920x1080x24'"

--- a/playbook/roles/selenium/tasks/main.yml
+++ b/playbook/roles/selenium/tasks/main.yml
@@ -47,17 +47,9 @@
   when: selenium_install_chrome
   tags: [configuration, selenium, selenium-chrome]
 
-- name: Get the latest release for chromedriver
-  uri:
-    url: http://chromedriver.storage.googleapis.com/LATEST_RELEASE
-    return_content: yes
-  register: chromedriver_latest
-  when: selenium_install_chrome
-  tags: [configuration, selenium, selenium-chrome]
-
 - name: Install chromedriver
   unarchive:
-    src: "http://chromedriver.storage.googleapis.com/{{ chromedriver_latest.content | trim }}/chromedriver_linux64.zip"
+    src: "http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip"
     dest: /usr/bin
     mode: 0755
     copy: no

--- a/playbook/roles/selenium/tasks/main.yml
+++ b/playbook/roles/selenium/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install JRE
   yum: pkg=jre state=installed
-  
+
 - name: Include OS-Specific variables
   include_vars: "{{ ansible_os_family }}.yml"
   tags: [configuration, selenium]
@@ -24,7 +24,7 @@
   package: name=firefox state=present
   when: selenium_install_firefox
   tags: [configuration, selenium, selenium-firefox]
-  
+
 - name: Get the latest release for geckodriver
   shell: 'curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep "browser_download_url.*linux64.tar.gz" | cut -d : -f 2,3 | tr -d \"'
   register: geckodriver_latest
@@ -49,7 +49,7 @@
 
 - name: Install chromedriver
   unarchive:
-    src: "http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip"
+    src: "http://chromedriver.storage.googleapis.com/{{ selenium_chromedriver }}/chromedriver_linux64.zip"
     dest: /usr/bin
     mode: 0755
     copy: no
@@ -59,7 +59,7 @@
 - name: Install xvfb
   package: name={{ selenium_xvfb_package }}
   tags: [configuration, selenium, selenium-xvfb]
-  
+
 - name: Install xvfb systemd unit file (for systemd systems)
   template:
     src: "xvfb-unit.j2"
@@ -89,7 +89,7 @@
     mode: 0755
   when: "ansible_service_mgr == 'systemd'"
   tags: [configuration, selenium, selenium-install]
-  
+
 - name: Register xvfb systemd service status (for systemd systems)
   shell: 'systemctl status xvfb | grep "active (running)"'
   when: "ansible_service_mgr == 'systemd'"


### PR DESCRIPTION
Latest chromedriver(2.31) is incompatible with GLIBC version running on wundertool.
`chromedriver: /lib64/libc.so.6: version "GLIBC_2.18" not found (required by chromedriver)`

Until there is better solution we can statically require last known good version of chromedriver.