### PR TITLE
Feature/allow hotlink prevention

### DIFF
--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -9,6 +9,7 @@ varnish:
   error_header_x_ua: "insert_GA_code"
   hotlink_forbidden: false
   hotlink_filetype_pattern: "pdf|doc|xls|ppt|zip|bz2|gzip"
+  hotlink_allow_no_referer: true
   acl_internal:
     - ip: 127.0.0.1
   acl_purge:

--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -7,6 +7,8 @@ varnish:
   error_header_x_site_name: "insert_sitename"
   error_header_x_sitetitle: "insert_site_title"
   error_header_x_ua: "insert_GA_code"
+  hotlink_forbidden: false
+  hotlink_filetype_pattern: "pdf|doc|xls|ppt|zip|bz2|gzip"
   acl_internal:
     - ip: 127.0.0.1
   acl_purge:

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -595,7 +595,11 @@ sub hotlink {
     req.url ~ "\.({{ varnish.hotlink_filetype_pattern }})(\?.*)?$"
   ) {
     # Only allow if referer is from one of our host.
-    if (!(
+    if (
+      {% if varnish.hotlink_allow_no_referer %}
+      req.http.referer &&
+      {% endif %}
+      !(
       {% for director in varnish.directors %}
       req.http.referer ~ "^(http|https)://{{ director.host}}" {% if not loop.last %} || {% endif %}
       {% endfor %}

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -594,7 +594,7 @@ sub hotlink {
     req.url ~ "^/sites/default/files/" &&
     req.url ~ "\.({{ varnish.hotlink_filetype_pattern }})(\?.*)?$"
   ) {
-    # Only allow if search engine or from one of our host.
+    # Only allow if referer is from one of our host.
     if (!(
       {% for director in varnish.directors %}
       req.http.referer ~ "^(http|https)://{{ director.host}}" {% if not loop.last %} || {% endif %}

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -116,6 +116,11 @@ sub vcl_recv {
     set req.http.sticky = std.random(1, 100);
   }
 
+  {% if varnish.hotlink_forbidden %}
+  # Call hotlink prevention sub.
+  call hotlink;
+  {% endif %}
+
   # Send traffic to the correct site director, determined by request domain name.
   if (req.http.host == "") {
     return (synth(404, "Need a host header"));
@@ -577,4 +582,26 @@ sub vcl_fini {
   # Typically used to clean up VMODs.
 
   return (ok);
+}
+
+sub hotlink {
+  # Prevent hotlinking of files. Called optionally from vcl_recv if hotlinking is forbidden.
+
+  if ((
+    {% for director in varnish.directors %}
+    req.http.host == "{{ director.host }}" {% if not loop.last %} || {% endif %}
+    {% endfor %}) &&
+    req.url ~ "^/sites/default/files/" &&
+    req.url ~ "\.({{ varnish.hotlink_filetype_pattern }})(\?.*)?$"
+  ) {
+    # Only allow if search engine or from one of our host.
+    if (!(
+      {% for director in varnish.directors %}
+      req.http.referer ~ "^(http|https)://{{ director.host}}" {% if not loop.last %} || {% endif %}
+      {% endfor %}
+      )
+    ) {
+      return (synth(403, "Not allowed."));
+    }
+  }
 }

--- a/playbook/roles/varnish/templates/varnish.params.j2
+++ b/playbook/roles/varnish/templates/varnish.params.j2
@@ -32,4 +32,4 @@ VARNISH_USER=varnish
 VARNISH_GROUP=varnish
 
 # Other options, see the man page varnishd(1)
-DAEMON_OPTS="-p thread_pool_min=100 -p thread_pool_max=1000 -p thread_pool_timeout=300 -p lru_interval=1800 -p max_restarts=6 -p http_range_support=on -p http_max_hdr=128 -p http_req_hdr_len=20000 -p http_resp_hdr_len=20000"
+DAEMON_OPTS="-p thread_pool_min=100 -p thread_pool_max=1000 -p thread_pool_timeout=300 -p lru_interval=1800 -p max_restarts=6 -p http_range_support=on -p http_max_hdr=128 -p http_req_hdr_len=20000 -p http_resp_hdr_len=20000 -p vcc_err_unref=off"

--- a/tests/test-php56.yml
+++ b/tests/test-php56.yml
@@ -176,6 +176,7 @@
         - ip: 127.0.0.1
       acl_upstream_proxy:
         - ip: 127.0.0.1
+      hotlink_forbidden: true
       directors:
         # One app
         - name: test_com_director

--- a/tests/test-php56.yml
+++ b/tests/test-php56.yml
@@ -177,6 +177,7 @@
       acl_upstream_proxy:
         - ip: 127.0.0.1
       hotlink_forbidden: true
+      hotlink_filetype_pattern: "pdf|doc"
       directors:
         # One app
         - name: test_com_director

--- a/tests/test-php56.yml
+++ b/tests/test-php56.yml
@@ -178,6 +178,7 @@
         - ip: 127.0.0.1
       hotlink_forbidden: true
       hotlink_filetype_pattern: "pdf|doc"
+      hotlink_allow_no_referer: true
       directors:
         # One app
         - name: test_com_director


### PR DESCRIPTION
We have a use case in one project where we need to prevent hotlinking of certain files.

This prevents external sites from doing so.