### PR TITLE
Disable UDP for NFS

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -68,7 +68,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if Gem.win_platform?
 		config.vm.synced_folder ".", "/vagrant"
 	else
-		config.vm.synced_folder ".", "/vagrant", type: :nfs
+		config.vm.synced_folder ".", "/vagrant", type: :nfs, nfs_udp: false
 	end
 
 	# Vagrant cachier


### PR DESCRIPTION
Fedora has recently updated to a more recent version of _nfs-utils_which does not have UDP enabled by default. This prevents NFS from mounting because Vagrant runs it with UDP by default. 

Tested and working with MacOS, Fedora and Ubuntu.