### PR TITLE
Update the the default box to latest because 1.1.2 is not available.

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		if INSTANCE_VERSION.to_s != ''
 			config.vm.box_version = INSTANCE_VERSION
 		else
-			config.vm.box_version = '1.1.2'
+			config.vm.box_version = '1.2.1'
 		end
 	end
 


### PR DESCRIPTION
While trying to build vagrant on one of the projects I got error:
==> default: Adding box 'geerlingguy/centos6' (v1.1.2) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/geerlingguy/boxes/centos6/versions/1.1.2/providers/virtualbox.box
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 404 Not Found


---

Installed fine with the latest version 1.2.1.