### PR TITLE
Remove duplicate key in dbserver configuration.

### DIFF
--- a/playbook/roles/dbserver/defaults/main.yml
+++ b/playbook/roles/dbserver/defaults/main.yml
@@ -7,7 +7,6 @@ mariadb_root_password: root
 max_connections: 500
 connection_timeout: 5
 wait_timeout: 60
-max_allowed_packet: 256M
 innodb_buffer_pool_size: 1024
 innodb_buffer_pool_instances: 6
 innodb_log_buffer_size: 8M


### PR DESCRIPTION
Running a new Wundertools instance, you get the following error:

```
[WARNING]: While constructing a mapping from /Users/florian/workspace/WunderTo
ols/ansible/playbook/roles/dbserver/defaults/main.yml, line 2, column 1, found
a duplicate dict key (max_allowed_packet). Using last defined value only.
```

There are indeed two entries. Since the last value is the one taking into effect, I would propose to remove the first entry.
