### PR TITLE
Ensure zzz-xdebug.ini file is created during provisioning.

### DIFF
--- a/playbook/roles/devtools/tasks/main.yml
+++ b/playbook/roles/devtools/tasks/main.yml
@@ -28,6 +28,7 @@
     option={{ item.1.key }}
     value={{ item.1.val }}
     state=present
+    create=yes
   with_subelements:
     - "{{ xdebug }}"
     - options


### PR DESCRIPTION
Ansible 2.2.* seems to require that we add explicitly the create=yes line. 

(The master branch already has this, this commit is meant only for the centos6 branch).

(very small thing, maybe pull request is even overkill.. but here it is)