### PR TITLE
Allow to specify custom http response headers for varnish via variables.

### DIFF
--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -18,6 +18,9 @@ varnish:
     - ip: 127.0.0.1
   acl_upstream_proxy:
     - ip: 127.0.0.1
+#  custom_http_response_headers:
+#    - name: Access-Control-Allow-Origin
+#      value: "*"
   directors:
     # One app
     - name: test_com_director

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -506,6 +506,13 @@ sub vcl_deliver {
   unset resp.http.X-Drupal-Cache-Tags;
   unset resp.http.X-Drupal-Cache-Contexts;
 
+  {% if varnish.custom_http_response_headers is defined %}
+  # Set custom response headers as set in the variables:
+    {% for header in varnish.custom_http_response_headers %}
+        set resp.http.{{ header.name }} = "{{ header.value }}";
+    {% endfor %}
+  {% endif %}
+
   return (deliver);
 }
 


### PR DESCRIPTION
- the headers are then set in the vcl_deliver block in the default.vlc file.
- commented out example added to the main.yml file in the varnish role.