### PR TITLE
Upgrade to latest stable version of MariaDB

### DIFF
--- a/playbook/roles/dbserver/defaults/main.yml
+++ b/playbook/roles/dbserver/defaults/main.yml
@@ -11,7 +11,6 @@ innodb_buffer_pool_size: 1024
 innodb_buffer_pool_instances: 6
 innodb_log_buffer_size: 8M
 innodb_log_file_size: 24M
-innodb_additional_mem_pool_size: 10M
 innodb_concurrency: 16
 innodb_lock_wait_timeout: 120
 

--- a/playbook/roles/dbserver/files/mariadb.repo
+++ b/playbook/roles/dbserver/files/mariadb.repo
@@ -1,7 +1,7 @@
-# MariaDB 10.1 CentOS repository list - created 2015-11-20 11:28 UTC
-# http://mariadb.org/mariadb/repositories/
+# MariaDB 10.2 CentOS repository list - created 2017-12-01 13:36 UTC
+# http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/10.1/centos7-amd64
+baseurl = http://yum.mariadb.org/10.2/centos7-amd64
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1

--- a/playbook/roles/dbserver/templates/my.cnf.j2
+++ b/playbook/roles/dbserver/templates/my.cnf.j2
@@ -91,7 +91,6 @@ innodb_file_per_table = 1
 innodb_open_files = 32768
 innodb_io_capacity = 400
 innodb_thread_concurrency = {{ innodb_concurrency }}
-innodb_additional_mem_pool_size = {{ innodb_additional_mem_pool_size }}
 innodb_read_io_threads = {{ innodb_concurrency }}
 innodb_write_io_threads = {{ innodb_concurrency }}
 innodb_flush_log_at_trx_commit = 0


### PR DESCRIPTION
Summary of changes and things to consider when upgrading from 10.1 to 10.2 can be read at https://mariadb.com/kb/en/library/upgrading-from-mariadb-101-to-mariadb-102/

Major new features in MariaDB 10.2:
- Window Functions
- mysqlbinlog now supports continuous binary log backups
- Recursive Common Table Expressions
- **JSON functions**  ( <= my personal favourite! )