### PR TITLE
Define hostmanager.ip_resolver to get DHCP working.

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -51,6 +51,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if INSTANCE_ALIASES.to_s != ''
       config.hostmanager.aliases = INSTANCE_ALIASES
     end
+    config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
+      if hostname = (vm.ssh_info && vm.ssh_info[:host])
+        `vagrant ssh -c "hostname -I"`.split()[1]
+      end
+    end
   end
 
 	config.vm.hostname = INSTANCE_HOSTNAME


### PR DESCRIPTION
Resolves #259 

To test change the ansible: branch under conf/project.yml to `feature/259-HostmanagerDHCPSupport` and recreate the box without ip defined in conf/vagrant_local.yml.