### PR TITLE
Add X-Forwarded-Port header to ssl_terminator conf

### DIFF
--- a/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
+++ b/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
@@ -200,6 +200,7 @@ server {
     # Most web apps can be configured to read this header and
     # understand that the current session is actually HTTPS.
     proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_set_header        X-Forwarded-Port  $server_port;
     add_header              Front-End-Https   on;
 
     {% if site.extra_headers is defined %}


### PR DESCRIPTION
The X-Forwarded-Port request header helps you identify the port that the client used to connect to the load balancer.

Some libraries (for instance 'onelogin/php-saml') rely on the port detection instead of protocol which is captured in X-Forwarded-Proto.