### PR TITLE
Adds db credentials to environment.

### DIFF
--- a/playbook/roles/php-fpm/defaults/main.yml
+++ b/playbook/roles/php-fpm/defaults/main.yml
@@ -78,6 +78,7 @@ php_env_vars:
     value: "{{ wkv_site_env }}"
 
 php_env_vars_include_db: False
+database_vars_expose_globally: False
 
 #php_disable_functions: phpinfo,exec,passthru,shell_exec,show_source,system,pcntl_exec,popen,posix_getpwuid,posix_kill,posix_mkfifo,posix_setpgid,posix_setsid,posix_setuid,posix_setuid,posix_uname,proc_nice
 

--- a/playbook/roles/php-fpm/defaults/main.yml
+++ b/playbook/roles/php-fpm/defaults/main.yml
@@ -78,7 +78,7 @@ php_env_vars:
     value: "{{ wkv_site_env }}"
 
 php_env_vars_include_db: False
-database_vars_expose_globally: False
+expose_php_vars_globally: False
 
 #php_disable_functions: phpinfo,exec,passthru,shell_exec,show_source,system,pcntl_exec,popen,posix_getpwuid,posix_kill,posix_mkfifo,posix_setpgid,posix_setsid,posix_setuid,posix_setuid,posix_uname,proc_nice
 

--- a/playbook/roles/php-fpm/tasks/main.yml
+++ b/playbook/roles/php-fpm/tasks/main.yml
@@ -54,6 +54,7 @@
   with_items:
     - "{{ databases }}"
   backup: yes
+  when: database_vars_expose_globally == True
 
 - name: Add php_extra_env_vars
   set_fact:

--- a/playbook/roles/php-fpm/tasks/main.yml
+++ b/playbook/roles/php-fpm/tasks/main.yml
@@ -41,6 +41,19 @@
     - "{{ databases }}"
   when: php_env_vars_include_db == True
 
+- name: Add db credentials to environment variables
+  blockinfile:
+    path: /etc/environment
+    block: |
+      DB_NAME_{{ item.name|upper }}={{ item.name }}
+      DB_USER_{{ item.name|upper }}={{ item.user }}
+      DB_PASS_{{ item.name|upper }}={{ item.pass }}
+      DB_HOST_{{ item.name|upper }}={{ item.host|default('127.0.0.1') }}
+      DB_PORT_{{ item.name|upper }}={{ item.port|default('3306') }}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.name|upper }}-DB"
+  with_items:
+    - "{{ databases }}"
+  backup: yes
 
 - name: Add php_extra_env_vars
   set_fact:

--- a/playbook/roles/php-fpm/tasks/main.yml
+++ b/playbook/roles/php-fpm/tasks/main.yml
@@ -41,21 +41,6 @@
     - "{{ databases }}"
   when: php_env_vars_include_db == True
 
-- name: Add db credentials to environment variables
-  blockinfile:
-    path: /etc/environment
-    block: |
-      DB_NAME_{{ item.name|upper }}={{ item.name }}
-      DB_USER_{{ item.name|upper }}={{ item.user }}
-      DB_PASS_{{ item.name|upper }}={{ item.pass }}
-      DB_HOST_{{ item.name|upper }}={{ item.host|default('127.0.0.1') }}
-      DB_PORT_{{ item.name|upper }}={{ item.port|default('3306') }}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.name|upper }}-DB"
-  with_items:
-    - "{{ databases }}"
-  backup: yes
-  when: database_vars_expose_globally == True
-
 - name: Add php_extra_env_vars
   set_fact:
     php_env_vars: >
@@ -74,6 +59,16 @@
         ]
       }}
     when: varnish_control_key is defined
+
+- name: Add php_env_vars to environment variables
+  blockinfile:
+    path: /etc/environment
+    block: |
+      {{ item.key }}={{ item.value }}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK PHP ENV VARS {{ item.key }}"
+  with_items: "{{ php_env_vars }}"
+  backup: yes
+  when: expose_php_vars_globally == True
 
 - yum:
     name={{ item }}


### PR DESCRIPTION
As mentioned in [Wundertools issue 183](https://github.com/wunderio/WunderTools/issues/183)  php env vars are not accessible by many tools. 
This fixes:
- support for drush 9
- support for drupal console
- support for codeception