### PR TITLE
Adds option to define if drupal will handle pdf and pptx files.

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -61,3 +61,5 @@ nginx_compression_level: 6
 
 allow_origin_fonts: false
 deny_robots: false
+
+drupal_handle_pdf_pptx: false

--- a/playbook/roles/nginx/templates/drupal.conf.j2
+++ b/playbook/roles/nginx/templates/drupal.conf.j2
@@ -90,6 +90,9 @@ location / {
     ## No need to bleed constant updates. Send the all shebang in one
     ## fell swoop.
     tcp_nodelay off;
+{% if drupal_handle_pdf_pptx %}
+    try_files $uri @drupal;
+{% endif %}
   }
 
   # Configure webfont access


### PR DESCRIPTION
Adds option to define if drupal will handle pdf and pptx files.
**Test:**

- Add `drupal_handle_pdf_pptx: true` to variables.yml
- Check that  /etc/nginx/conf.d/drupal.conf contains `try_files $uri @drupal;` in PDFs and powerpoint config block.