### PR TITLE
unsetting one header fixed an upstream error. 

### DIFF
--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -520,6 +520,7 @@ sub vcl_deliver {
   unset resp.http.x-host;
 
   # Comment these for easier Drupal cache tag debugging in development.
+  unset resp.http.cache-tags;
   unset resp.http.X-Drupal-Cache-Tags;
   unset resp.http.X-Drupal-Cache-Contexts;
 


### PR DESCRIPTION
unsetting cache-tags helped fix "upstream sent too big header while reading response header from upstream" error. It seems that for D8 the naming convention has changed.