### PR TITLE
Updating static variable into an modifiable one. 

### DIFF
--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -106,7 +106,7 @@ http {
   merge_slashes off;
 
   types_hash_max_size 8192;
-  server_names_hash_bucket_size 64;
+  server_names_hash_bucket_size {{ nginx_conf.server_names_hash_bucket_size|default('64') }};
 
   ## Compression.
   gzip              on;


### PR DESCRIPTION
Nginx playbook already has it like this. 

Old static valuecauses issues when you want to deploy just sslterminator and with a bigger value than 64. 