### PR TITLE
Unified nginx/sslterminator roles. 

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -52,6 +52,7 @@ nginx_conf:
   client_max_body_size: 100M
   client_body_buffer_size: 128k
   proxy_read_timeout: 60
+  server_names_hash_bucket_size: 64
 
 # Allow connection limit bypass from certain ip addresses
 #nginx_conn_limit_whitelist:

--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -5,6 +5,16 @@ nginx_real_ip: 127.0.0.1
 sslterminator_papertrail_follow:
   - /var/log/nginx/ssl-*error.log
 
+nginx_conf:
+  client_header_timeout: 10
+  client_body_timeout: 120
+  send_timeout: 120
+  keepalive_timeout: "15 10"
+  client_max_body_size: 100M
+  client_body_buffer_size: 128k
+  proxy_read_timeout: 60
+  server_names_hash_bucket_size: 64
+
 sslterminators:
   - server_name: www.test.com
     server_forwards: test.com

--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -90,13 +90,13 @@ http {
   sendfile                on;
   tcp_nopush              on;
   tcp_nodelay             on;
-  client_header_timeout   10;
-  client_body_timeout     120;
-  send_timeout            120;
-  keepalive_timeout       15 10;
-  client_max_body_size    100M;
-  client_body_buffer_size 128k;
-  proxy_read_timeout      60;
+  client_header_timeout   {{ nginx_conf.client_header_timeout | default(10) }};
+  client_body_timeout     {{ nginx_conf.client_body_timeout | default(120) }};
+  send_timeout            {{ nginx_conf.send_timeout | default(120) }};
+  keepalive_timeout       {{ nginx_conf.keepalive_timeout | default("15 10") }};
+  client_max_body_size    {{ nginx_conf.client_max_body_size | default("100M") }};
+  client_body_buffer_size {{ nginx_conf.client_body_buffer_size | default("128k") }};
+  proxy_read_timeout      {{ nginx_conf.proxy_read_timeout | default(60) }};
 
   ## Reset lingering timed out connections. Deflect DDoS.
   reset_timedout_connection on;


### PR DESCRIPTION
If sslterminator was run separately it would just configure static values overwriting possible nginx custom values.

Also if just sslterminator role is run right now alone it would fail complaining no `nginx_conf` being defined.