### PR TITLE
Bump the default base box version.

### DIFF
--- a/vagrantfile.rb
+++ b/vagrantfile.rb
@@ -63,7 +63,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		if INSTANCE_VERSION.to_s != ''
 			config.vm.box_version = INSTANCE_VERSION
 		else
-			config.vm.box_version = '1.2.0'
+			config.vm.box_version = '1.2.3'
 		end
 	end
   


### PR DESCRIPTION
In some projects I have encountered the following problem when trying to provision a specific ansible role with `provision.sh` script:

```
❯ ./provision.sh -t drush vagrant
PLAY [default] ******************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************
fatal: [default]: UNREACHABLE! => changed=false 
  msg: 'SSH Error: data could not be sent to remote host "127.0.0.1". Make sure this host can be reached over ssh'
  unreachable: true
    to retry, use: --limit @/home/arturs/Sites/project-test/conf/vagrant.retry

PLAY RECAP **********************************************************************************************************************************************************************************************
default                    : ok=0    changed=0    unreachable=1    failed=0   
```

Today I finally tracked it down to the Geerlingguy base box version. If no specific version is defined in `vagrant_local.yml` file it will default to 1.2.0 (and not the latest available version that I thought it does) By updating it to a slightly more recent version that's used in some other project where the provisioning works without issues I was able to get rid of the problem. 

I did not have time to test the very latest box but at least this version is working.