### PR TITLE
AJM-157: Allow to set custom varnish probe interval and probe timeout

### DIFF
--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -5,6 +5,8 @@ varnish:
   port: 8081
   memory: 1G
   probe_resource_url: "_ping.php"
+  probe_interval: "5s"
+  probe_timeout: "1s"
   error_header_cache_control: "no-cache, max-age: 0, must-revalidate"
   error_header_x_site_name: "insert_sitename"
   error_header_x_sitetitle: "insert_site_title"

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -25,8 +25,8 @@ backend {{ backend.name }} {
       "Host: {{ director.host }}"
       "Connection: close";
 
-    .interval  = 5s; # check the health of each backend every 5 seconds
-    .timeout   = 1s; # timing out after 1 second.
+    .interval  = {{ varnish.probe_interval | default('5s') }}; # check the health of each backend every n seconds
+    .timeout   = {{ varnish.probe_timeout| default('1s') }}; # timing out after n seconds
     .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
     .threshold = 3;  # considered healthy, otherwise it will be marked as sick
   }


### PR DESCRIPTION
AJM-157
Varnish timeout 1s can be a problem for load-intensive (altia) projects running locally.
This will allow to set custom varnish probe interval and probe timeout.
If they are not set - will fall back to present values (interval 5s, timeout 1s)
