### PR TITLE
Prevents autodiscover.xml requests

### DIFF
--- a/playbook/roles/nginx/templates/drupal.conf.j2
+++ b/playbook/roles/nginx/templates/drupal.conf.j2
@@ -234,3 +234,7 @@ location ~ /\. { return 404; access_log off; log_not_found off; }
 location ~* ^.+\.php$ {
     return 404;
 }
+
+## Avoid logs to be filled with unnecessary autodiscover.xml entries
+location ~ /autodiscover/autodiscover.xml { return 404; access_log off; log_not_found off; }
+


### PR DESCRIPTION
Handle autodiscover.xml requests by nginx avoiding additional processing and unnecessary log entries.

(Autodiscover.xml is tool/service in Exchange Servers)