### PR TITLE
logrotate fix

### DIFF
--- a/playbook/roles/base/files/logrotate/syslog
+++ b/playbook/roles/base/files/logrotate/syslog
@@ -4,6 +4,7 @@
 /var/log/secure
 /var/log/spooler
 {
+    missingok
     sharedscripts
     rotate 7
     compress


### PR DESCRIPTION
If any log file mentioned in syslog conf is missing none of the logs get rotated. "missingok" fixes the issue.