### PR TITLE
Support for varnish director.type

### DIFF
--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -24,6 +24,7 @@ varnish:
   directors:
     # One app
     - name: test_com_director
+      type: hash
       host: test.com
       backends:
         - name: test1_web

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -68,12 +68,17 @@ sub vcl_init {
   # Called when VCL is loaded, before any requests pass through it.
   # Typically used to initialize VMODs.
   {% for director in varnish.directors %}
-  new {{ director.name }} = directors.hash();
-  {% for backend in director.backends %}
-  {% if backend.ignore is not defined %}
-  {{ director.name }}.add_backend({{ backend.name }}, 1);
-  {% endif %}
-  {% endfor %}
+    new {{ director.name }} = directors.{{ director.type }}();
+    {% for backend in director.backends %} 
+      # Note that the order in which adding is done matters for fallback director
+      {% if backend.ignore is not defined %}
+        {% if director.type == 'fallback' %}
+          {{ director.name }}.add_backend({{ backend.name }});
+        {% else %}
+          {{ director.name }}.add_backend({{ backend.name }}, 1);
+        {% endif %}
+      {% endif %}
+    {% endfor %}
   {% endfor %}
   # Extra directors
 }
@@ -138,7 +143,11 @@ sub vcl_recv {
   }
   {% for director in varnish.directors %}
   elsif (req.http.host ~ "{{ director.host }}"){
-    set req.backend_hint = {{ director.name }}.backend(req.http.sticky);
+    {% if director.type == 'fallback' %}
+      set req.backend_hint = {{ director.name }}.backend();
+    {% else %}
+      set req.backend_hint = {{ director.name }}.backend(req.http.sticky);
+    {% endif %}
   }
   {% endfor %}
   else {

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -68,11 +68,11 @@ sub vcl_init {
   # Called when VCL is loaded, before any requests pass through it.
   # Typically used to initialize VMODs.
   {% for director in varnish.directors %}
-    new {{ director.name }} = directors.{{ director.type }}();
+    new {{ director.name }} = directors.{{ director.type | default('hash') }}();
     {% for backend in director.backends %} 
       # Note that the order in which adding is done matters for fallback director
       {% if backend.ignore is not defined %}
-        {% if director.type == 'fallback' %}
+        {% if director.type is defined and director.type == 'fallback' %}
           {{ director.name }}.add_backend({{ backend.name }});
         {% else %}
           {{ director.name }}.add_backend({{ backend.name }}, 1);
@@ -143,7 +143,7 @@ sub vcl_recv {
   }
   {% for director in varnish.directors %}
   elsif (req.http.host ~ "{{ director.host }}"){
-    {% if director.type == 'fallback' %}
+    {% if director.type is defined and director.type == 'fallback' %}
       set req.backend_hint = {{ director.name }}.backend();
     {% else %}
       set req.backend_hint = {{ director.name }}.backend(req.http.sticky);


### PR DESCRIPTION
Added support for varnish director.type
Default type: hash - one we used as hardcoded value
Use type when adding backend and if director is fallback 
 - only one parameter passed to add_backend
 - sticky sessions not used
