### PR TITLE
Feature/refactor filebeat

### DIFF
--- a/playbook/roles/filebeat/defaults/main.yml
+++ b/playbook/roles/filebeat/defaults/main.yml
@@ -14,14 +14,19 @@ filebeat:
     ca_cert: ""
   # default groups of files to watch and rules for their (not)shipping
   log_files:
-    - group: "basic"
+    - group: "secure"
+      paths:
+        - /var/log/secure
+    - group: "messages"
       paths:
         - /var/log/messages
-        - /var/log/secure
+      include: # if include is defined, filebeat will ship only lines that match rules
+        - '(?i)err' 
+        - '(?i)warn'
     - group: "maillog"
       paths:   
         - /var/log/maillog
-      include: # if include is defined, filebeat will ship only lines that match rules
+      include:
         - '(?i)err' 
         - '(?i)warn'
         - '(?i)bounce'

--- a/playbook/roles/filebeat/templates/beats.repo.j2
+++ b/playbook/roles/filebeat/templates/beats.repo.j2
@@ -1,6 +1,6 @@
-[elastic-{{ filebeat_version }}]
-name=Elastic repository for {{ filebeat_version }} packages
-baseurl=https://artifacts.elastic.co/packages/{{ filebeat_version }}/yum
+[elastic-{{ filebeat.version }}]
+name=Elastic repository for {{ filebeat.version }} packages
+baseurl=https://artifacts.elastic.co/packages/{{ filebeat.version }}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/playbook/roles/filebeat/templates/filebeat_escloud.yml.j2
+++ b/playbook/roles/filebeat/templates/filebeat_escloud.yml.j2
@@ -17,6 +17,8 @@ filebeat.inputs:
   fields:
     log_type: syslog
   fields_under_root: true
+  # Start shipping only newly added lines
+  tail_files: true
 {% endif %}
 {% endfor %}
 
@@ -25,9 +27,6 @@ filebeat.inputs:
 {% endif %}
 
 filebeat.registry_file: /var/lib/filebeat/registry
-
-# Start shipping only newly added lines
-tail_files: true
 
 #==================== End modules configuration ==========================
 setup.template.settings:

--- a/playbook/roles/filebeat/templates/filebeat_logstash.yml.j2
+++ b/playbook/roles/filebeat/templates/filebeat_logstash.yml.j2
@@ -17,6 +17,8 @@ filebeat.inputs:
   fields:
     log_type: syslog
   fields_under_root: true
+  # Start shipping only newly added lines
+  tail_files: true
 {% endif %}
 {% endfor %}
 
@@ -25,9 +27,6 @@ filebeat.inputs:
 {% endif %}
 
 filebeat.registry_file: /var/lib/filebeat/registry
-
-# Start shipping only newly added lines
-tail_files: true
 
 output.logstash:
   hosts: ["{{ filebeat.logstash.endpoint }}"]


### PR DESCRIPTION
This feature enables shipping only error and warning logs from /var/log/messages and use tail_files: true in each filegroup to avoid shipping old logs.