### PR TITLE
Add log_files_extra support to filebeat

### DIFF
--- a/playbook/roles/filebeat/defaults/main.yml
+++ b/playbook/roles/filebeat/defaults/main.yml
@@ -54,7 +54,7 @@ filebeat:
         - '.*(?i)notice.*'
 
 
-# to add extra inputs, define additional filebeat.log_files entries in playbooks
+# to add extra inputs, define filebeat.log_files_extra with same structure as filebeat.log_files
 # or add
 # filebeat.custom_inputs_block with syntax described in url 
 # https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-input-log.html

--- a/playbook/roles/filebeat/tasks/main.yml
+++ b/playbook/roles/filebeat/tasks/main.yml
@@ -17,6 +17,12 @@
   action: command hostname
   register: hostname
 
+- name: Merge filebeat.log_files with filebeat.log_files_extra
+  set_fact:
+    filebeat:
+      log_files: "{{ filebeat.log_files + filebeat.log_files_extra }}"
+  when: filebeat.log_files_extra is defined
+
 - name: Check if required service(s) present
   shell: "systemctl status {{ item.reqservice }} | grep running | wc -l"
   register: reqservice_checks


### PR DESCRIPTION
This feature adds log_files_extra variable support to filebeat.
We need to use this because even with hash_behaviour=merge if default list is defined and list with same name is defined in project - only the later will be used and not merged.