### PR TITLE
Use ansible service_facts to check running services

### DIFF
--- a/playbook/roles/filebeat/tasks/main.yml
+++ b/playbook/roles/filebeat/tasks/main.yml
@@ -23,11 +23,9 @@
       log_files: "{{ filebeat.log_files + filebeat.log_files_extra }}"
   when: filebeat.log_files_extra is defined
 
-- name: Check if required service(s) present
-  shell: "systemctl status {{ item.reqservice }} | grep running | wc -l"
-  register: reqservice_checks
-  loop: "{{ filebeat.log_files }}"
-  when: item.reqservice is defined
+# Need this to check if required service(s) present when using template
+- name: Populate service facts
+  service_facts:
 
 # copy cert and key values from vault to server
 - name: Copy client.crt to server

--- a/playbook/roles/filebeat/templates/filebeat_escloud.yml.j2
+++ b/playbook/roles/filebeat/templates/filebeat_escloud.yml.j2
@@ -1,7 +1,9 @@
 filebeat.inputs:
 {% for logfiles in filebeat.log_files %}
 {% if ((logfiles.reqservice is not defined) or 
-      ((logfiles.reqservice is defined) and (reqservice_checks.results[loop.index0].stdout == "1"))) %}
+      (logfiles.reqservice is defined) and (logfiles.reqservice+'.service' in ansible_facts.services) and (ansible_facts.services[logfiles.reqservice+'.service'].state == "running") or
+      (logfiles.reqservice is defined) and (logfiles.reqservice in ansible_facts.services) and (ansible_facts.services[logfiles.reqservice].state == "running")
+      ) %}
 
 - type: log
   paths:

--- a/playbook/roles/filebeat/templates/filebeat_logstash.yml.j2
+++ b/playbook/roles/filebeat/templates/filebeat_logstash.yml.j2
@@ -1,7 +1,9 @@
 filebeat.inputs:
 {% for logfiles in filebeat.log_files %}
 {% if ((logfiles.reqservice is not defined) or 
-      ((logfiles.reqservice is defined) and (reqservice_checks.results[loop.index0].stdout == "1"))) %}
+      (logfiles.reqservice is defined) and (logfiles.reqservice+'.service' in ansible_facts.services) and (ansible_facts.services[logfiles.reqservice+'.service'].state == "running") or
+      (logfiles.reqservice is defined) and (logfiles.reqservice in ansible_facts.services) and (ansible_facts.services[logfiles.reqservice].state == "running")
+      ) %}
 
 - type: log
   paths:


### PR DESCRIPTION
Change from custom bash script (only supported with systemd)  to more generic ansible function service_facts to check running services.