### PR TITLE
Allow disabling referrer policy

### DIFF
--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -99,8 +99,10 @@ http {
   ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
   add_header X-XSS-Protection '1; mode=block';
 
+  {% if nginx_disable_referrer_policy is not defined %}
   # Protect users privacy
   add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
+  {% endif %}
 
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;

--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -99,9 +99,11 @@ http {
   ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
   add_header X-XSS-Protection '1; mode=block';
 
+  {% if nginx_disable_referrer_policy is not defined %}
   # Protect users privacy
   add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
-
+  {% endif %}
+  
   ## Block MIME type sniffing on IE.
   add_header X-Content-Options nosniff;
 


### PR DESCRIPTION
Referrer policy was moved from `nginx_disable_content_security_policy` block
https://github.com/wunderio/WunderMachina/commit/d937eaef251734a9916af21c4fdf72138664956b

so the client had issues with some advertisements.

This change allows disabling referrer policy optionally. Still enabled by default for the rest.

set `nginx_disable_referrer_policy = True` to use this