### PR TITLE
Feature/sslterm default root proxy config overridden

### DIFF
--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -28,6 +28,10 @@ sslterminators:
     #  - code: 451
     #    page: 451.html
     #    path: /var/www/html
+    default_root_proxy_config_overridden: False # If this is set to True, defaults as 
+    # proxy_pass, proxy_redirect and other proxy_... defaults 
+    # will NOT be included in / location config
+    #
     # extra conditions for location / can be defined:
     #extra_conditions: |
     #if ($illegal = yes) {

--- a/playbook/roles/sslterminator/templates/nginx_upstream_sslterminated.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx_upstream_sslterminated.conf.j2
@@ -3,11 +3,11 @@
 ################################################################################
 
 {% for site in sslterminators %}
-
+{% if (site.default_root_proxy_config_overridden is not defined) or (site.default_root_proxy_config_overridden == False) %}
 upstream {{ site.server_name|replace(".", "") }} {
 {% for server in site.backends %}
   server {{ server }};
 {% endfor %}
 }
-
+{% endif %}
 {% endfor %}

--- a/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
+++ b/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
@@ -205,6 +205,7 @@ server {
     {% if site.extra_conditions is defined %}
     {{ site.extra_conditions }}
     {% endif %}
+    {% if (site.default_root_proxy_config_overridden is not defined) or (site.default_root_proxy_config_overridden == False) %}
     # Pass the request on to Varnish.
     proxy_pass http://{{ site.server_name|replace(".", "") }};
 
@@ -232,7 +233,7 @@ server {
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_set_header        X-Forwarded-Port  $server_port;
     add_header              Front-End-Https   on;
-
+    {% endif %}
     {% if site.extra_headers is defined %}
     {% for header in site.extra_headers %}
     add_header {{ header.name }} {{ header.value }};


### PR DESCRIPTION
This feature adds option to override default proxy configuration for location / so that when setting `default_root_proxy_config_overridden` to True we can define custom proxy_pass, proxy_redirect and other proxy_ .. configs.
Also Since proxy_pass directive also is overriden, we check `default_root_proxy_config_overridden` value and not define any upstream hosts if it is True (otherwise not used 'backend' config wold be required for provisioning to work)