### PR TITLE
Fix xdebug package name when PHP 7.3 is used.

### DIFF
--- a/playbook/roles/devtools/tasks/main.yml
+++ b/playbook/roles/devtools/tasks/main.yml
@@ -42,9 +42,13 @@
 # Php XDebug.
 #
 
-- name: PHP | XDebug
+- name: PHP | Install XDebug for PHP 7.3
+  yum: pkg=php73-php-pecl-xdebug state=installed
+  when: enable_xdebug == true and php_package == "php73remi"
+
+- name: PHP | Install XDebug for PHP <7.3
   yum: pkg={{ php_package }}-pecl-xdebug state=installed
-  when: enable_xdebug== true
+  when: enable_xdebug == true and php_package != "php73remi"
 
 - name: PHP | Set up xdebug.ini
   ini_file: dest=/etc/php.d/zzz-xdebug.ini


### PR DESCRIPTION
PHP packages from REMI repositories use a different xdebug package name.

The fix is suboptimal because it will require an update when the next PHP version comes out.