### PR TITLE
Allow setting custom default ttl

### DIFF
--- a/playbook/roles/varnish/defaults/main.yml
+++ b/playbook/roles/varnish/defaults/main.yml
@@ -37,6 +37,14 @@ varnish:
 #      operator: "~"
 #      value: "^.*/somepath/.*$"
 #      action: "return(pass);" #note that you need a ";"
+#
+# We can set different ttl depending on custom conditions 
+# by adding directives in vcl_backend_response_append_block
+#  vcl_backend_response_append_block: |2
+#      if (beresp.status == 200 && beresp.ttl > 0s) {
+#        set beresp.ttl = 1m;
+#        set beresp.http.x-ttl = "1m"; 
+#      }
 # # Multiple apps
 #   - name: test_com_director
 #     host: test.com

--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -497,7 +497,11 @@ sub vcl_backend_response {
   }
 
   # Allow items to be stale if needed.
-  set beresp.grace = 2h;
+  set beresp.grace = 2h
+
+{% if varnish.vcl_backend_response_block is defined %}
+{{ varnish.vcl_backend_response_append_block }}
+{% endif %}
 
   return (deliver);
 }


### PR DESCRIPTION
This feature allows setting custom ttl for cached objects. If `varnish.default_x_ttl` is set, it will use that variable, otherwise will set previous default (10m).