### PR TITLE
ChromeDriver and Selenium version updates

### DIFF
--- a/playbook/roles/selenium/defaults/main.yml
+++ b/playbook/roles/selenium/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 # defaults file for selenium
 selenium_install_dir: /opt
-selenium_version: "3.11.0"
+selenium_version: "3.141.59"
 selenium_install_firefox: yes
 selenium_install_chrome: yes
-selenium_chromedriver: "2.37"
+selenium_chromedriver: "76.0.3809.68"
 selenium_display_id: "1"
 selenium_port: 4444
 selenium_xvfb_args: "--server-args='-screen 0, 1920x1080x24'"

--- a/playbook/roles/selenium/tasks/main.yml
+++ b/playbook/roles/selenium/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: Install Chrome (Centos)
   yum:
-    name: https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+    name: http://dist.control.lth.se/public/CentOS-7/x86_64/google.x86_64/google-chrome-beta-74.0.3729.61-1.x86_64.rpm
     state: present
   when: selenium_install_chrome
   tags: [configuration, selenium, selenium-chrome]


### PR DESCRIPTION
We're downloading the latest version of GoogleChrome while using a fixed version of ChromeDriver and Selenium. Things have reached the point where they no longer work together reliably. So we update ChromeDriver and Selenium and fix GoogleChrome version to one that works. 