### PR TITLE
Varnish regex for static file requests

### DIFF
--- a/playbook/roles/varnish/templates/default.vcl.j2
+++ b/playbook/roles/varnish/templates/default.vcl.j2
@@ -451,7 +451,7 @@ sub vcl_backend_response {
     set beresp.http.x-ttl = "10m";
   }
 
-  if (bereq.url ~ "\.(jpg|jpeg|gif|png|svg|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)\??.*$") {
+  if (bereq.url ~ "\/\/[^\?]*\.(jpg|jpeg|gif|png|svg|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf).*$") {
     # Strip any cookies before static files are inserted into cache.
     unset beresp.http.set-cookie;
     if(beresp.status == 200){
@@ -467,7 +467,7 @@ sub vcl_backend_response {
   # Large static files are delivered directly to the end-user without
   # waiting for Varnish to fully read the file first.
   # Varnish 4 fully supports Streaming, so use streaming here to avoid locking.
-  if (bereq.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|pdf|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+  if (bereq.url ~ "\/\/[^\?]*\.(mp[34]|rar|tar|tgz|gz|pdf|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm).*$") {
     unset beresp.http.set-cookie;
     set beresp.do_stream = true;  # Check memory usage it'll grow in fetch_chunksize blocks (128k by default) if the backend doesn't send a Content-Length header, so only enable it for big objects
     set beresp.do_gzip = false;   # Don't try to compress it for storage


### PR DESCRIPTION
In our current project we identified an issue where session cookies were being stripped from requests like `http://www.example.com/some/path?foo=bar.pdf` due to Varnish treating it as a static file request when it actually isn't.
The modified regex should match extensions while ignoring the query string. Regex experts feel free to correct me there.