### PR TITLE
Added an ignore error for PHP repo install. On reprovisioning the sta…

### DIFF
--- a/playbook/roles/php-fpm/tasks/repo_php7.yml
+++ b/playbook/roles/php-fpm/tasks/repo_php7.yml
@@ -10,6 +10,7 @@
 
 - name: Install repositories
   yum: pkg={{item}} state=present
+  ignore_errors: yes
   with_items:
     - "https://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-15.ius.centos7.noarch.rpm"
   when: distro == "centos7"


### PR DESCRIPTION
…tus message was "Nothing to do" which caused the provisioning to fail.