### PR TITLE
Use the actual Centos 7 / RHEL 7 repository so it would stay up-to-date

### DIFF
--- a/playbook/roles/php-fpm/tasks/repo_php7.yml
+++ b/playbook/roles/php-fpm/tasks/repo_php7.yml
@@ -12,7 +12,7 @@
   yum: pkg={{item}} state=present
   ignore_errors: yes
   with_items:
-    - "https://dl.iuscommunity.org/pub/ius/stable/CentOS/7/x86_64/ius-release-1.0-15.ius.centos7.noarch.rpm"
+    - "https://centos7.iuscommunity.org/ius-release.rpm"
   when: distro == "centos7"
 
 # Mariadb repository for client

--- a/playbook/roles/php-fpm/tasks/repo_php7.yml
+++ b/playbook/roles/php-fpm/tasks/repo_php7.yml
@@ -5,7 +5,7 @@
 - name: Install repositories
   yum: pkg={{item}} state=present
   with_items:
-    - "https://dl.iuscommunity.org/pub/ius/stable/Redhat/7/x86_64/ius-release-1.0-15.ius.el7.noarch.rpm"
+    - "https://rhel7.iuscommunity.org/ius-release.rpm"
   when: distro == "rhel7"
 
 - name: Install repositories


### PR DESCRIPTION
I [had an issue setting up Wundertools ](https://wunder.slack.com/archives/C57QVFXG8/p1569927409056300) since the repository which was used to install php-fpm was outdated. It seems that the solution instead of setting a specific version, would be to use a Centos 7 / RHEL 7 latest repositories.

https://plone.lucidsolutions.co.nz/linux/centos/ius-repository-for-centos-7