### PR TITLE
Had to add real_ip_recursive line because if proxy had address addres…

### DIFF
--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -32,6 +32,7 @@ http {
   {% endfor %}
   {% endif %}
   real_ip_header     X-Forwarded-For;
+  real_ip_recursive on;
 
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;

--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -32,7 +32,8 @@ http {
   {% endfor %}
   {% endif %}
   real_ip_header     X-Forwarded-For;
-
+  real_ip_recursive on;
+  
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
   index index.htm, index.html, index.php;


### PR DESCRIPTION
…ses as a multivalue in the format of "client, proxy" it would only show the proxy IP in the logs even with set_real_ip_from properly defined.