### PR TITLE
Add php-pecl-zip module to default php packages

### DIFF
--- a/playbook/roles/php-fpm/tasks/php73remi.yml
+++ b/playbook/roles/php-fpm/tasks/php73remi.yml
@@ -29,4 +29,5 @@
     - "php-xmlrpc"
     - "php-pecl-apcu"
     - "php-bcmath"
+    - "php-pecl-zip"
 


### PR DESCRIPTION
Add PHP zip module to default php packages as some drupal module's functionality depends on it (ie. Webform export)