### PR TITLE
ES plugin binary name depending on ES version

### DIFF
--- a/playbook/roles/elasticsearch/tasks/main.yml
+++ b/playbook/roles/elasticsearch/tasks/main.yml
@@ -24,16 +24,20 @@
 - name: Install Elasticsearch.
   yum: pkg=elasticsearch state=installed
 
+- name: Set Elasticsearch plugin binary name depending on ES version
+  set_fact:
+    plugin_bin_name: "{{ 'plugin' if elasticsearch_version < 6 else 'elasticsearch-plugin' }}"
+
 - name: Removing Plugins if they exist
   action: >
-    shell bin/plugin remove {{ item.shortname }}
+    shell bin/{{ es_plugin_bin_name }} remove {{ item.shortname }}
     chdir={{ elasticsearch_config.home_dir }}
   with_items: "{{ elasticsearch_plugins }}"
   ignore_errors: yes
 
 - name: Installing Plugins
   action: >
-    shell bin/plugin install {{ item.name }}
+    shell bin/{{ es_plugin_bin_name }} install {{ item.name }}
     chdir={{ elasticsearch_config.home_dir }}
   with_items: "{{ elasticsearch_plugins }}"
   ignore_errors: yes

--- a/playbook/roles/elasticsearch/tasks/main.yml
+++ b/playbook/roles/elasticsearch/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Set Elasticsearch plugin binary name depending on ES version
   set_fact:
-    plugin_bin_name: "{{ 'plugin' if elasticsearch_version < 6 else 'elasticsearch-plugin' }}"
+    es_plugin_bin_name: "{{ 'plugin' if elasticsearch_version < 6 else 'elasticsearch-plugin' }}"
 
 - name: Removing Plugins if they exist
   action: >


### PR DESCRIPTION
This fix sets ES plugin binary name depending on ES version (there is no file bin/plugin starting from ES6), so we set it depending on version.