### PR TITLE
Use port 8008 for nginx monit tests

### DIFF
--- a/playbook/roles/monit/templates/monitrc.j2
+++ b/playbook/roles/monit/templates/monitrc.j2
@@ -69,7 +69,7 @@ check process nginx with pidfile /var/run/nginx.pid
    group apache
    start program = "/usr/bin/systemctl start nginx"
    stop program = "/usr/bin/systemctl stop nginx"
-   if failed host 127.0.0.1 port 8082 protocol http
+   if failed host 127.0.0.1 port 8008 protocol http
      and request '/index.html'
      with timeout 5 seconds
      then restart

--- a/playbook/roles/nginx/files/nginx/test/nginx_test.conf
+++ b/playbook/roles/nginx/files/nginx/test/nginx_test.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8082;
+    listen 8008;
     server_name 127.0.0.1;
     root /var/www/test;
     access_log off;

--- a/playbook/roles/sslterminator/files/nginx/test/nginx_test.conf
+++ b/playbook/roles/sslterminator/files/nginx/test/nginx_test.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8082;
+    listen 8008;
     server_name 127.0.0.1;
     root /var/www/test;
     access_log off;


### PR DESCRIPTION
### Problem

In some centos versions, it seems that selinux assigns port 8082 to us_cli_port which means nginx could not use that port for http.

### Solution

Move the port to 8008 which is assigned by selinux for http.

### Changes

- Change nginx configuration to listen on port 8008 for monit test.
- Change monit configuration to call on port 8008