### PR TITLE
Feature/nginx custom arbeit lim

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -54,7 +54,6 @@ nginx_conf:
   proxy_read_timeout: 60
   server_names_hash_bucket_size: 64
 
-nginx_compression_level: 6
 # Allow connection limit bypass from certain ip addresses
 #nginx_conn_limit_whitelist:
 #  - 127.0.0.1/32

--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -53,6 +53,7 @@ nginx_conf:
   client_body_buffer_size: 128k
   proxy_read_timeout: 60
   server_names_hash_bucket_size: 64
+  arbeit_limit_conn: 64
 
 # Allow connection limit bypass from certain ip addresses
 #nginx_conn_limit_whitelist:

--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -53,7 +53,7 @@ nginx_conf:
   client_body_buffer_size: 128k
   proxy_read_timeout: 60
   server_names_hash_bucket_size: 64
-  arbeit_limit_conn: 64
+  arbeit_limit_conn: 32
 
 # Allow connection limit bypass from certain ip addresses
 #nginx_conn_limit_whitelist:

--- a/playbook/roles/nginx/templates/all_apps.conf.j2
+++ b/playbook/roles/nginx/templates/all_apps.conf.j2
@@ -39,7 +39,7 @@ server {
   error_log /var/log/nginx/http-{{ site.server_name }}-error.log;
 
   {% if nginx_disable_arbeit is not defined %}
-  limit_conn arbeit 32;
+  limit_conn arbeit {{ nginx_conf.arbeit_limit_conn | default(32) }};
   {% endif %}
 
   {% if app_dir_aliases is defined %}


### PR DESCRIPTION
This feature allows to define custom arbeit_limit_conn as sometimes we want to change from default 32 to arbitrary value.
Also in this PR is fixed nginx_compression_level duplicate value in nginx defaults.