### PR TITLE
Introduce bauth_override_block for sslterminator

### DIFF
--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -43,6 +43,9 @@ sslterminators:
     #   forward_to: https://somehost/somepath/$1
     #   forward_condition: '$remote_addr !~* xxx.xxx.xxx.xxx'
     #   type: permanent
+    # bauth_override_block: | # lines below are included directly in ssl_terminators.conf, use semicolumns
+    #   # commented lines to test bauth_override_block inclusion overriding 
+    #   # LB wide bauth definitions in ssl_terminators.conf
 
 httpforwards:
   - server_name: www.test.com

--- a/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
+++ b/playbook/roles/sslterminator/templates/ssl_terminators.conf.j2
@@ -155,7 +155,10 @@ server {
   access_log /var/log/nginx/ssl-{{ site.server_name }}-access.log main buffer=32k;
   error_log /var/log/nginx/ssl-{{ site.server_name }}-error.log;
 
-  {% if basicauth_enabled == True %}
+  {% if site.bauth_override_block is defined %}
+  # Default basicauth settings overriden!
+  {{ site.bauth_override_block }}
+  {% elif basicauth_enabled == True %}
 
   satisfy  any;
   {% for ip in basicauth_ip %}


### PR DESCRIPTION
We sometimes need different bauth settings for one vhost than for other(s) on the same LB. 
This feature introduces option to define bauth_override_block in sslterminators for one or multiple server_name(s). e.g.

```
sslterminators:
  - server_name: www.test.com
    bauth_override_block: | 
      # commented lines to test bauth_override_block inclusion overriding 
      # LB wide bauth definitions in ssl_terminators.conf
```