### PR TITLE
Add option to set custom X-Robots-Tag in nginx

### DIFF
--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -80,3 +80,9 @@ hsts_include_subdomains: " includeSubDomains;"
 # Set to true to install nginx-module-geoip 
 # and load ngx_http_geoip_module in nginx.conf 
 nginx_geoip_enabled: false
+
+# Setting this variable in your playbooks as in example below
+# will add X-Robots-Tag header to site locations that match the host:/path regex
+# nginx_x_robots_tag_header_rules: |
+#   "~(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
+#   default  '';

--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -84,5 +84,5 @@ nginx_geoip_enabled: false
 # Setting this variable in your playbooks as in example below
 # will add X-Robots-Tag header to site locations that match the host:/path regex
 # nginx_x_robots_tag_header_rules: |
-#   "~(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
+#   "~*(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
 #   default  '';

--- a/playbook/roles/nginx/defaults/main.yml
+++ b/playbook/roles/nginx/defaults/main.yml
@@ -60,7 +60,14 @@ nginx_conf:
 #  - 127.0.0.1/32
 
 allow_origin_fonts: false
+
+# Handling web crawlers - per environment via /robots.txt
 deny_robots: false
+# Handling web crawlers - per domain and path via X-Robots-Tag header
+# This example will add X-Robots-Tag header to site paths that match the host:/path regex
+# nginx_x_robots_tag_header_rules: |
+#   "~*(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
+#   default  '';
 
 #Block specific files not in nginx 404 list. As you are adding to an existing list of files formatting is important even for one file.
 #example: |file1|file2|file3
@@ -81,8 +88,3 @@ hsts_include_subdomains: " includeSubDomains;"
 # and load ngx_http_geoip_module in nginx.conf 
 nginx_geoip_enabled: false
 
-# Setting this variable in your playbooks as in example below
-# will add X-Robots-Tag header to site locations that match the host:/path regex
-# nginx_x_robots_tag_header_rules: |
-#   "~*(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
-#   default  '';

--- a/playbook/roles/nginx/templates/nginx.conf.j2
+++ b/playbook/roles/nginx/templates/nginx.conf.j2
@@ -75,6 +75,14 @@ http {
   limit_conn_zone $limit zone=arbeit:10m;
   {% endif %}
 
+  {% if nginx_x_robots_tag_header_rules is defined %}
+  ## Tell robots not to index pages on specified domains:/locations
+  map "$http_host:$request_uri" $x_robots_tag_header {
+    {{ nginx_x_robots_tag_header_rules }}
+  }
+  add_header  X-Robots-Tag $x_robots_tag_header;
+  {% endif %}
+
   ## Use a SSL/TLS cache for SSL session resume. This needs to be
   ## here (in this context, for session resumption to work. See this
   ## thread on the Nginx mailing list:

--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -84,3 +84,9 @@ hsts_include_subdomains: " includeSubDomains;"
 # Set to true to install nginx-module-geoip 
 # and load ngx_http_geoip_module in nginx.conf 
 nginx_geoip_enabled: false
+
+# Setting this variable in your playbooks as in example below
+# will add X-Robots-Tag header to site locations that match the host:/path regex
+# nginx_x_robots_tag_header_rules: |
+#   "~(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
+#   default  '';

--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -84,9 +84,3 @@ hsts_include_subdomains: " includeSubDomains;"
 # Set to true to install nginx-module-geoip 
 # and load ngx_http_geoip_module in nginx.conf 
 nginx_geoip_enabled: false
-
-# Setting this variable in your playbooks as in example below
-# will add X-Robots-Tag header to site locations that match the host:/path regex
-# nginx_x_robots_tag_header_rules: |
-#   "~*(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
-#   default  '';

--- a/playbook/roles/sslterminator/defaults/main.yml
+++ b/playbook/roles/sslterminator/defaults/main.yml
@@ -88,5 +88,5 @@ nginx_geoip_enabled: false
 # Setting this variable in your playbooks as in example below
 # will add X-Robots-Tag header to site locations that match the host:/path regex
 # nginx_x_robots_tag_header_rules: |
-#   "~(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
+#   "~*(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
 #   default  '';

--- a/playbook/roles/sslterminator/templates/nginx.conf.j2
+++ b/playbook/roles/sslterminator/templates/nginx.conf.j2
@@ -75,6 +75,14 @@ http {
   limit_conn_zone $limit zone=arbeit:10m;
   {% endif %}
 
+  {% if nginx_x_robots_tag_header_rules is defined %}
+  ## Tell robots not to index pages on specified domains:/locations
+  map "$http_host:$request_uri" $x_robots_tag_header {
+    {{ nginx_x_robots_tag_header_rules }}
+  }
+  add_header  X-Robots-Tag $x_robots_tag_header;
+  {% endif %}
+
   ## Use a SSL/TLS cache for SSL session resume. This needs to be
   ## here (in this context, for session resumption to work. See this
   ## thread on the Nginx mailing list:


### PR DESCRIPTION
Some sites need to tell web crawlers not to index their content if these sites are accessed via specific (e.g. back-up or test) domain name. 
This feature allows to set variable nginx_x_robots_tag_header_rules in playbook with regexes of domain names and paths and header values that should contain the X-Robots-Tag header. 
Variable setting example below (also it is provided in /defaults/main.yml)
```
nginx_x_robots_tag_header_rules: |
   "~(dev|develop|stage|prod).mytestsitedomain.com:/.*$" "noindex, nofollow, nosnippet, noarchive";
   default  '';
```