### PR TITLE
Update pypi source url.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,5 +1,5 @@
 [[source]]
-url = "https://pypi.python.org/simple"
+url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 


### PR DESCRIPTION
Current url is outdated and forwarded to new one. We had problems with the forwarding in one of the provisioning, let's update it instead.