### PR TITLE
Fix php env variable provisioning errors

### DIFF
--- a/playbook/roles/php-fpm/tasks/main.yml
+++ b/playbook/roles/php-fpm/tasks/main.yml
@@ -60,7 +60,7 @@
         [
           {
             "key": 'VARNISH_CONTROL_KEY',
-            "value": "{{ varnish_control_key }}"
+            "value": varnish_control_key
           }
         ]
       }}
@@ -68,7 +68,7 @@
 
 - name: Add php_env_vars to environment variables
   blockinfile:
-    path: /etc/environment
+    dest: /etc/environment
     backup: yes
     block: |
       {{ item.key }}={{ item.value }}


### PR DESCRIPTION
Fixes two issues during php env variable provisioning:

- `{{ varnish_control_key }}` being treated as a string literal rather than a template variable
- `Missing required arguments: dest` error